### PR TITLE
Fix bug in parser that prevented code in docs.

### DIFF
--- a/docs/ElunaDoc/parser.py
+++ b/docs/ElunaDoc/parser.py
@@ -108,7 +108,7 @@ class ClassParser(object):
 
     # These are used to parse method documentation.
     start_regex = re.compile(r"\s*/\*\*")  # The start of documentation, i.e. /**
-    body_regex = re.compile(r"\s*\s?\*\s*(.*)")  # The "body", i.e. a * and optionally some descriptive text.
+    body_regex = re.compile(r"\s*\s?\*\s?(.*)")  # The "body", i.e. a * and optionally some descriptive text.
     # An extra optional space (\s?) was thrown in to make it different from `class_body_regex`.
 
     param_regex = re.compile(r"""\s*\*\s@param\s    # The @param tag starts with opt. whitespace followed by "* @param ".


### PR DESCRIPTION
Now you can add code to a doc just by adding 4 spaces in front of it (i.e. Markdown format) instead of having to use pre tags.
