### PR TITLE
Make the register functions optionally return a cancel callback.

### DIFF
--- a/ElunaUtility.h
+++ b/ElunaUtility.h
@@ -130,11 +130,11 @@ namespace ElunaUtil
     public:
 
 #ifdef USING_BOOST
-        typedef boost::shared_mutex LockType;
+        typedef boost::recursive_mutex LockType;
         typedef boost::shared_lock<boost::shared_mutex> ReadGuard;
         typedef boost::unique_lock<boost::shared_mutex> WriteGuard;
 #else
-        typedef ACE_RW_Thread_Mutex LockType;
+        typedef ACE_Recursive_Thread_Mutex LockType;
         typedef ACE_Read_Guard<LockType> ReadGuard;
         typedef ACE_Write_Guard<LockType> WriteGuard;
 #endif

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -272,7 +272,7 @@ public:
     bool ShouldReload() const { return reload; }
     bool IsEnabled() const { return enabled && IsInitialized(); }
     bool HasLuaState() const { return L != NULL; }
-    void Register(uint8 reg, uint32 id, uint64 guid, uint32 instanceId, uint32 evt, int func, uint32 shots);
+    int Register(lua_State* L, uint8 reg, uint32 id, uint64 guid, uint32 instanceId, uint32 evt, int func, uint32 shots, bool returnCallback);
 
     // Non-static pushes, to be used in hooks.
     // These just call the correct static version with the main thread's Lua state.


### PR DESCRIPTION
It's now possible to have complete flexibility with cancelling bindings, i.e. it's possible to re-implement all of the other ways to cancel bindings using the callback (in addition to all the fancy new things you can do).

This sytem has been designed with complete safety in mind:
 - It is safe to call the callback more than once (does nothing after the
   first call).
 - The callback does not expire, and can be stored for as long as
   necessary.
 - ~~If a callback is returned, there is no other way to cancel the binding
   (again, due to safety).~~ Fixed with https://github.com/ElunaLuaEngine/Eluna/commit/e14e22a24c08a233e82698d4e4edace860dd68f8.