### PR TITLE
Added player methods: LearnPetSpell and RemovePetSpell

### DIFF
--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
 * This program is free software licensed under GPL version 3
 * Please see the included DOCS/LICENSE.md for more information
@@ -685,6 +685,8 @@ ElunaRegister<Player> PlayerMethods[] =
     // {"KilledPlayerCredit", &LuaPlayer::KilledPlayerCredit},                              // :KilledPlayerCredit() - UNDOCUMENTED - Satisfies a player kill for the player
     // {"KillGOCredit", &LuaPlayer::KillGOCredit},                                          // :KillGOCredit(GOEntry[, GUID]) - UNDOCUMENTED - Credits the player for destroying a GO, guid is optional
     { "TalkedToCreature", &LuaPlayer::TalkedToCreature },
+    { "LearnPetSpell", &LuaPlayer::LearnPetSpell },
+    { "RemovePetSpell", &LuaPlayer::RemovePetSpell },
 #if (!defined(TBC) && !defined(CLASSIC))
     { "ResetPetTalents", &LuaPlayer::ResetPetTalents },
 #endif

--- a/PlayerMethods.h
+++ b/PlayerMethods.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
 * This program is free software licensed under GPL version 3
 * Please see the included DOCS/LICENSE.md for more information
@@ -2056,6 +2056,44 @@ namespace LuaPlayer
         player->SetMovement((PlayerMovementType)pType);
         return 0;
     }*/
+
+    /**
+    * Teaches the [Player]s pet the [Spell] specified by entry ID
+    *
+    * @param uint32 spellId
+    */
+    int LearnPetSpell(Eluna* /*E*/, lua_State* L, Player* player)
+    {
+        uint32 id = Eluna::CHECKVAL<uint32>(L, 2);
+
+        Pet* pet = player->GetPet();
+        if (pet)
+            pet->learnSpell(id);
+        return 0;
+    }
+
+    /**
+    * Removes the [Spell] from the [Player]s pet
+    *
+    * @param uint32 entry : entry of a [Spell]
+    * @param bool learnLowRank = true
+    * @param bool clear_ab = false
+    */
+    int RemovePetSpell(Eluna* /*E*/, lua_State* L, Player* player)
+    {
+        uint32 entry = Eluna::CHECKVAL<uint32>(L, 2);
+        bool learn_low_rank = Eluna::CHECKVAL<bool>(L, 3, true);
+        bool clear_ab = Eluna::CHECKVAL<bool>(L, 4, false);
+
+        Pet* pet = player->GetPet();
+        if (pet)
+        {
+            if (pet->unlearnSpell(entry, learn_low_rank, clear_ab))
+                player->PetSpellInitialize();
+        }
+
+        return 0;
+    }
 
 #if (!defined(TBC) && !defined(CLASSIC))
     /**


### PR DESCRIPTION
Moved the call to _player->PetSpellInitialize()_ into _RemovePetSpell_

I checked all 7 cores mentioned in the Eluna readme, pretty sure they all use the same function name capitalization and arguments, and _pet::unlearnSpell_ seems to have the required boolean return value. Unfortunately all 7 also have the minor issue I mentioned before, necessitating a call to _PetSpellInitialize_.

I've only tested it on TrinityCore 3.3.5.

It seems like the Classic/TBC flavors of MaNGOS don't send a system message to players in _Pet::unlearnSpell_. I guess it's a client limitation since they don't define the opcode _SMSG_PET_REMOVED_SPELL_.