### PR TITLE
fix some compiler warnings about unused variables

### DIFF
--- a/MapMethods.h
+++ b/MapMethods.h
@@ -263,6 +263,7 @@ namespace LuaMap
      */
     int SetWeather(lua_State* L, Map* map)
     {
+        (void)map; // ensure that the variable is referenced in order to pass compiler checks
         uint32 zoneId = Eluna::CHECKVAL<uint32>(L, 2);
         uint32 weatherType = Eluna::CHECKVAL<uint32>(L, 3);
         float grade = Eluna::CHECKVAL<float>(L, 4);

--- a/PlayerMethods.h
+++ b/PlayerMethods.h
@@ -2474,6 +2474,7 @@ namespace LuaPlayer
      */
     int LeaveBattleground(lua_State* L, Player* player)
     {
+        (void)L; // ensure that the variable is referenced in order to pass compiler checks
 #ifndef AZEROTHCORE
         bool teleToEntryPoint = Eluna::CHECKVAL<bool>(L, 2, true);
         player->LeaveBattleground(teleToEntryPoint);
@@ -3493,6 +3494,7 @@ namespace LuaPlayer
     {
         uint32 category = Eluna::CHECKVAL<uint32>(L, 2);
         bool update = Eluna::CHECKVAL<bool>(L, 3, true);
+        (void)update; // ensure that the variable is referenced in order to pass compiler checks
 
 #ifdef TRINITY
         player->GetSpellHistory()->ResetCooldowns([category](SpellHistory::CooldownStorageType::iterator itr) -> bool

--- a/UnitMethods.h
+++ b/UnitMethods.h
@@ -1494,6 +1494,7 @@ namespace LuaUnit
         uint32 type = Eluna::CHECKVAL<uint32>(L, 2);
         float rate = Eluna::CHECKVAL<float>(L, 3);
         bool forced = Eluna::CHECKVAL<bool>(L, 4, false);
+        (void)forced; // ensure that the variable is referenced in order to pass compiler checks
         if (type >= MAX_MOVE_TYPE)
             return luaL_argerror(L, 2, "valid UnitMoveType expected");
 #if defined TRINITY || AZEROTHCORE
@@ -2276,6 +2277,7 @@ namespace LuaUnit
     {
         const char* msg = Eluna::CHECKVAL<const char*>(L, 2);
         uint32 lang = Eluna::CHECKVAL<uint32>(L, 3);
+        (void)lang; // ensure that the variable is referenced in order to pass compiler checks
         Player* receiver = Eluna::CHECKOBJ<Player>(L, 4);
         bool bossWhisper = Eluna::CHECKVAL<bool>(L, 5, false);
         if (std::string(msg).length() > 0)


### PR DESCRIPTION
Fix the following compiler warnings, which is necessary to include Eluna into the AzerothCore Travis run (see https://github.com/azerothcore/mod-eluna-lua-engine/pull/11):

```
LuaEngine/UnitMethods.h:1496:14: fatal error: unused variable 'forced' [-Wunused-variable]
        bool forced = Eluna::CHECKVAL<bool>(L, 4, false);
```
```
LuaEngine/UnitMethods.h:2279:16: fatal error: unused variable 'lang' [-Wunused-variable]
        uint32 lang = Eluna::CHECKVAL<uint32>(L, 3);
```
```
LuaEngine/PlayerMethods.h:2475:38: fatal error: unused parameter 'L' [-Wunused-parameter]
    int LeaveBattleground(lua_State* L, Player* player)
```
```
LuaEngine/PlayerMethods.h:3496:14: fatal error: unused variable 'update' [-Wunused-variable]
        bool update = Eluna::CHECKVAL<bool>(L, 3, true);
```
```
LuaEngine/MapMethods.h:264:39: fatal error: unused parameter 'map' [-Wunused-parameter]
    int SetWeather(lua_State* L, Map* map)
```