### PR TITLE
fix some compiler warnings about unused variables, part 2

### DIFF
--- a/CreatureMethods.h
+++ b/CreatureMethods.h
@@ -593,7 +593,7 @@ namespace LuaCreature
         else
             Eluna::Push(L, 0);
 #elif AZEROTHCORE
-        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell))
+        if (sSpellMgr->GetSpellInfo(spell))
             Eluna::Push(L, creature->GetSpellCooldown(spell));
         else
             Eluna::Push(L, 0);

--- a/GroupMethods.h
+++ b/GroupMethods.h
@@ -135,7 +135,7 @@ namespace LuaGroup
             return 1;
         }
 
-        if (Group* invitedgroup = player->GetGroupInvite())
+        if (player->GetGroupInvite())
             player->UninviteFromGroup();
 
 #if defined TRINITY || AZEROTHCORE

--- a/PlayerMethods.h
+++ b/PlayerMethods.h
@@ -3986,9 +3986,9 @@ namespace LuaPlayer
         if (player->GetGroup() || invited->GetGroup())
             return 0;
 
-        if (Group* invitedgroup = player->GetGroupInvite())
+        if (player->GetGroupInvite())
             player->UninviteFromGroup();
-        if (Group* invitedgroup = invited->GetGroupInvite())
+        if (invited->GetGroupInvite())
             invited->UninviteFromGroup();
 
         // Try create new group


### PR DESCRIPTION
Sorry, but I forgot in PR #288 that AC not only checks clang 7 but also clang 3.8 compilation. This PR fixes the following compiler warnings:
```
modules/mod-eluna-lua-engine/LuaEngine/PlayerMethods.h:3989:20: fatal error: unused variable 'invitedgroup' [-Wunused-variable]
        if (Group* invitedgroup = player->GetGroupInvite())
```
```
modules/mod-eluna-lua-engine/LuaEngine/PlayerMethods.h:3991:20: fatal error: unused variable 'invitedgroup' [-Wunused-variable]
        if (Group* invitedgroup = invited->GetGroupInvite())
```
```
modules/mod-eluna-lua-engine/LuaEngine/CreatureMethods.h:596:30: fatal error: unused variable 'spellInfo' [-Wunused-variable]
        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell))
```
```
modules/mod-eluna-lua-engine/LuaEngine/GroupMethods.h:138:20: fatal error: unused variable 'invitedgroup' [-Wunused-variable]
        if (Group* invitedgroup = player->GetGroupInvite())
```