### PR TITLE
Fixed Creature_Event_On_Spawn getting called twice

### DIFF
--- a/ElunaCreatureAI.h
+++ b/ElunaCreatureAI.h
@@ -38,15 +38,16 @@ struct ElunaCreatureAI : ScriptedAI
     void UpdateAI(uint32 diff) override
 #endif
     {
+#ifdef TRINITY
+        //Spawns are handled by Creature.cpp - in function Creature::Update() 
+#else
         if (justSpawned)
         {
             justSpawned = false;
-#ifdef TRINITY
-            JustAppeared();
-#else
+
             JustRespawned();
-#endif
         }
+#endif
 
         if (!movepoints.empty())
         {


### PR DESCRIPTION
On Trinity, ElunaCreatureAI called JustAppeared() while the core also called JustAppeared(), resulting in two events getting triggered.
Fixes #312 