### PR TITLE
Implement LearnAllRecipes and CreatePet player methods

### DIFF
--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -659,6 +659,8 @@ ElunaRegister<Player> PlayerMethods[] =
     { "SendPacket", &LuaPlayer::SendPacket },
     { "SendAddonMessage", &LuaPlayer::SendAddonMessage },
     { "ModifyMoney", &LuaPlayer::ModifyMoney },
+    { "LearnAllRecipes", &LuaPlayer::LearnAllRecipes },
+    { "CreatePet", &LuaPlayer::CreatePet },
     { "LearnSpell", &LuaPlayer::LearnSpell },
     { "LearnTalent", &LuaPlayer::LearnTalent },
     { "RemoveItem", &LuaPlayer::RemoveItem },


### PR DESCRIPTION
Continuation of https://github.com/ElunaLuaEngine/Eluna/pull/267
Previous PR's repo or branch was removed.

> Allows player to learn all recipes for an specified skill id. (.learn all recipes xxxx)
Create an pet from a creature with given id that will get the level of the player.

> This was made using TC. Didnt tested on other cores.

Should be tested on all cores before merge