### PR TITLE
fix(AzerothCore): correct mistake in GuildMethods.h

### DIFF
--- a/GuildMethods.h
+++ b/GuildMethods.h
@@ -277,8 +277,7 @@ namespace LuaGuild
         CharacterDatabaseTransaction trans(nullptr);
         guild->DeleteMember(trans, player->GET_GUID(), isDisbanding);
 #elif defined AZEROTHCORE
-        SQLTransaction trans(nullptr);
-        guild->DeleteMember(trans, player->GET_GUID(), isDisbanding);
+        guild->DeleteMember(player->GET_GUID(), isDisbanding);
 #else
         guild->DelMember(player->GET_GUID(), isDisbanding);
 #endif


### PR DESCRIPTION
`DeleteMember` is declared as follows in AzerothCore:

```c++
void DeleteMember(uint64 guid, bool isDisbanding = false, bool isKicked = false, bool canDeleteGuild = false);
```

so the first parameter should be `guid`, not an `SQLTransaction`