### PR TITLE
Global:SendMail should return the GUIDs of the created items

### DIFF
--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2158,19 +2158,16 @@ namespace LuaGlobalFunctions
 #endif
                 draft.AddItem(item);
 
+
+                if (mailGUID <= 0)
+                {
 #if defined AZEROTHCORE
-                if (mailGUID <= 0)
-                {
                     mailGUID = item->GetGUIDLow();
-                    Eluna::Push(L, mailGUID);
-                }
 #elif defined TRINITY
-                if (mailGUID <= 0)
-                {
                     mailGUID = item->GetGUID();
+#endif
                     Eluna::Push(L, mailGUID);
                 }
-#endif
                 ++addedItems;
             }
         }

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2158,7 +2158,7 @@ namespace LuaGlobalFunctions
 #endif
                 draft.AddItem(item);
 
-                if (!mailGUID > 0)
+                if (mailGUID <= 0)
                 {
                     mailGUID = item->GetGUIDLow();
                     Eluna::Push(L, mailGUID);

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2128,6 +2128,7 @@ namespace LuaGlobalFunctions
         SQLTransaction trans = CharacterDatabase.BeginTransaction();
 #endif
         uint8 addedItems = 0;
+        uint32 mailGUID = 0;
         while (addedItems <= MAX_MAIL_ITEMS && i + 2 <= argAmount)
         {
             uint32 entry = Eluna::CHECKVAL<uint32>(L, ++i);
@@ -2156,6 +2157,13 @@ namespace LuaGlobalFunctions
                 item->SaveToDB();
 #endif
                 draft.AddItem(item);
+
+                if (!mailGUID > 0)
+                {
+                    mailGUID = item->GetGUIDLow();
+                    Eluna::Push(L, mailGUID);
+                }
+
                 ++addedItems;
             }
         }
@@ -2167,7 +2175,7 @@ namespace LuaGlobalFunctions
 #else
         draft.SendMailTo(MailReceiver(receiverPlayer, MAKE_NEW_GUID(receiverGUIDLow, 0, HIGHGUID_PLAYER)), sender);
 #endif
-        return 0;
+        return 1;
     }
 
     /**

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2158,12 +2158,19 @@ namespace LuaGlobalFunctions
 #endif
                 draft.AddItem(item);
 
+#if defined AZEROTHCORE
                 if (mailGUID <= 0)
                 {
                     mailGUID = item->GetGUIDLow();
                     Eluna::Push(L, mailGUID);
                 }
-
+#elif defined TRINITY
+                if (mailGUID <= 0)
+                {
+                    mailGUID = item->GetGUID();
+                    Eluna::Push(L, mailGUID);
+                }
+#endif
                 ++addedItems;
             }
         }
@@ -2175,7 +2182,11 @@ namespace LuaGlobalFunctions
 #else
         draft.SendMailTo(MailReceiver(receiverPlayer, MAKE_NEW_GUID(receiverGUIDLow, 0, HIGHGUID_PLAYER)), sender);
 #endif
+#if defined TRINITY || AZEROTHCORE
         return 1;
+#else
+        return 0;
+#endif
     }
 
     /**

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2093,6 +2093,7 @@ namespace LuaGlobalFunctions
      * @param uint32 cod = 0 : cod money amount
      * @param uint32 entry = 0 : entry of an [Item] to send with mail
      * @param uint32 amount = 0 : amount of the [Item] to send with mail
+     * @return uint32 itemGUIDlow : low GUID of the item. Up to 12 values returned, returns nil if no further items are sent
      */
     int SendMail(lua_State* L)
     {

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2128,7 +2128,6 @@ namespace LuaGlobalFunctions
         SQLTransaction trans = CharacterDatabase.BeginTransaction();
 #endif
         uint8 addedItems = 0;
-        uint32 mailGUID = 0;
         while (addedItems <= MAX_MAIL_ITEMS && i + 2 <= argAmount)
         {
             uint32 entry = Eluna::CHECKVAL<uint32>(L, ++i);
@@ -2157,17 +2156,9 @@ namespace LuaGlobalFunctions
                 item->SaveToDB();
 #endif
                 draft.AddItem(item);
-
-
-                if (mailGUID <= 0)
-                {
 #if defined AZEROTHCORE
-                    mailGUID = item->GetGUIDLow();
-#elif defined TRINITY
-                    mailGUID = item->GetGUID();
+                Eluna::Push(L, item->GetGUIDLow());
 #endif
-                    Eluna::Push(L, mailGUID);
-                }
                 ++addedItems;
             }
         }
@@ -2179,8 +2170,8 @@ namespace LuaGlobalFunctions
 #else
         draft.SendMailTo(MailReceiver(receiverPlayer, MAKE_NEW_GUID(receiverGUIDLow, 0, HIGHGUID_PLAYER)), sender);
 #endif
-#if defined TRINITY || AZEROTHCORE
-        return 1;
+#if defined AZEROTHCORE
+        return addedItems;
 #else
         return 0;
 #endif

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -2156,7 +2156,9 @@ namespace LuaGlobalFunctions
                 item->SaveToDB();
 #endif
                 draft.AddItem(item);
-#if defined AZEROTHCORE
+#if defined TRINITY
+                Eluna::Push(L, item->GetGUID().GetCounter());
+#else
                 Eluna::Push(L, item->GetGUIDLow());
 #endif
                 ++addedItems;
@@ -2170,11 +2172,7 @@ namespace LuaGlobalFunctions
 #else
         draft.SendMailTo(MailReceiver(receiverPlayer, MAKE_NEW_GUID(receiverGUIDLow, 0, HIGHGUID_PLAYER)), sender);
 #endif
-#if defined AZEROTHCORE
         return addedItems;
-#else
-        return 0;
-#endif
     }
 
     /**


### PR DESCRIPTION
Currently Global:SendMail returns nothing.

In my issue https://github.com/ElunaLuaEngine/Eluna/issues/346 i suggest to let it return the guid's of the items created.

~~Not knowing C++ well, i added code which can return the guid of the first item created by SendMail. 
It is kind of a workaround, so any advice in how to return all item GUIDs is appreciated.~~

The latest commit makes the SendMail command return all GUIDs of the created items, ~~only for Azerothcore.~~ for all supported cores.