### PR TITLE
Add Player::OnQuestComplete()

### DIFF
--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -700,7 +700,7 @@ namespace LuaGlobalFunctions
      *     // UNUSED                               =     40,       // (event, player)
      *     // UNUSED                               =     41,       // (event, player)
      *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
-     *     PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, creature, quest)
+     *     PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, gameobject, quest)
      * };
      * </pre>
      *

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -700,6 +700,7 @@ namespace LuaGlobalFunctions
      *     // UNUSED                               =     40,       // (event, player)
      *     // UNUSED                               =     41,       // (event, player)
      *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+     *     PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, creature, quest)
      * };
      * </pre>
      *

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -700,7 +700,7 @@ namespace LuaGlobalFunctions
      *     // UNUSED                               =     40,       // (event, player)
      *     // UNUSED                               =     41,       // (event, player)
      *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
-     *     PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, gameobject, quest)
+     *     PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, object, quest)
      * };
      * </pre>
      *

--- a/Hooks.h
+++ b/Hooks.h
@@ -204,7 +204,7 @@ namespace Hooks
         // UNUSED                               =     40,       // (event, player)
         // UNUSED                               =     41,       // (event, player)
         PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
-        PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, gameobject, quest)
+        PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, object, quest)
 
         PLAYER_EVENT_COUNT
     };

--- a/Hooks.h
+++ b/Hooks.h
@@ -204,7 +204,7 @@ namespace Hooks
         // UNUSED                               =     40,       // (event, player)
         // UNUSED                               =     41,       // (event, player)
         PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
-        PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, creature, quest)
+        PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, gameobject, quest)
 
         PLAYER_EVENT_COUNT
     };

--- a/Hooks.h
+++ b/Hooks.h
@@ -204,6 +204,7 @@ namespace Hooks
         // UNUSED                               =     40,       // (event, player)
         // UNUSED                               =     41,       // (event, player)
         PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+        PLAYER_EVENT_ON_QUEST_COMPLETE          =     43,       // (event, player, creature, quest)
 
         PLAYER_EVENT_COUNT
     };

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -460,7 +460,7 @@ public:
     void OnUpdateZone(Player* pPlayer, uint32 newZone, uint32 newArea);
     void OnMapChanged(Player* pPlayer);
     void HandleGossipSelectOption(Player* pPlayer, uint32 menuId, uint32 sender, uint32 action, const std::string& code);
-    void OnQuestComplete(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest);
+    void OnQuestComplete(Player* pPlayer, Object* pObject, Quest const* pQuest);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -460,7 +460,7 @@ public:
     void OnUpdateZone(Player* pPlayer, uint32 newZone, uint32 newArea);
     void OnMapChanged(Player* pPlayer);
     void HandleGossipSelectOption(Player* pPlayer, uint32 menuId, uint32 sender, uint32 action, const std::string& code);
-    void OnQuestComplete(Player* pPlayer, Creature* pCreature, Quest const* pQuest);
+    void OnQuestComplete(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -460,6 +460,7 @@ public:
     void OnUpdateZone(Player* pPlayer, uint32 newZone, uint32 newArea);
     void OnMapChanged(Player* pPlayer);
     void HandleGossipSelectOption(Player* pPlayer, uint32 menuId, uint32 sender, uint32 action, const std::string& code);
+    void OnQuestComplete(Player* pPlayer, Creature* pCreature, Quest const* pQuest);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/PlayerHooks.cpp
+++ b/PlayerHooks.cpp
@@ -106,6 +106,15 @@ void Eluna::OnQuestAbandon(Player* pPlayer, uint32 questId)
     CallAllFunctions(PlayerEventBindings, key);
 }
 
+void Eluna::OnQuestComplete(Player* pPlayer, Creature* creature, Quest const* pQuest)
+{
+    START_HOOK(PLAYER_EVENT_ON_QUEST_COMPLETE);
+    Push(pPlayer);
+    Push(creature);
+    Push(questId);
+    CallAllFunctions(PlayerEventBindings, key);
+}
+
 void Eluna::OnEquip(Player* pPlayer, Item* pItem, uint8 bag, uint8 slot)
 {
     START_HOOK(PLAYER_EVENT_ON_EQUIP);

--- a/PlayerHooks.cpp
+++ b/PlayerHooks.cpp
@@ -106,12 +106,12 @@ void Eluna::OnQuestAbandon(Player* pPlayer, uint32 questId)
     CallAllFunctions(PlayerEventBindings, key);
 }
 
-void Eluna::OnQuestComplete(Player* pPlayer, Creature* creature, Quest const* pQuest)
+void Eluna::OnQuestComplete(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest)
 {
     START_HOOK(PLAYER_EVENT_ON_QUEST_COMPLETE);
     Push(pPlayer);
-    Push(creature);
-    Push(questId);
+    Push(pGameObject);
+    Push(pQuest);
     CallAllFunctions(PlayerEventBindings, key);
 }
 

--- a/PlayerHooks.cpp
+++ b/PlayerHooks.cpp
@@ -106,11 +106,11 @@ void Eluna::OnQuestAbandon(Player* pPlayer, uint32 questId)
     CallAllFunctions(PlayerEventBindings, key);
 }
 
-void Eluna::OnQuestComplete(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest)
+void Eluna::OnQuestComplete(Player* pPlayer, Object* pObject, Quest const* pQuest)
 {
     START_HOOK(PLAYER_EVENT_ON_QUEST_COMPLETE);
     Push(pPlayer);
-    Push(pGameObject);
+    Push(pObject);
     Push(pQuest);
     CallAllFunctions(PlayerEventBindings, key);
 }


### PR DESCRIPTION
Here is a hook attached to the player completing a quest. I chose event number 43 as it was the next in line. I am not sure if there is a more solid methodology. :)

local function OnQuestComplete(event, player, creature, quest)
    print(player:GetName().." completed quest "..quest:GetId())
end
RegisterPlayerEvent(43, questItemTest.OnQuestComplete)

prints on AC: Theboss completed quest 7803
