### PR TITLE
Add OnExploreNewArea

### DIFF
--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -700,6 +700,7 @@ namespace LuaGlobalFunctions
      *     // UNUSED                               =     40,       // (event, player)
      *     // UNUSED                               =     41,       // (event, player)
      *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+     *     PLAYER_EVENT_ON_EXPLORE_NEW_AREA        =     44,       // (event, player, areaid)
      * };
      * </pre>
      *

--- a/Hooks.h
+++ b/Hooks.h
@@ -204,6 +204,7 @@ namespace Hooks
         // UNUSED                               =     40,       // (event, player)
         // UNUSED                               =     41,       // (event, player)
         PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+        PLAYER_EVENT_ON_EXPLORE_NEW_AREA        =     44,       // (event, player, areaid)
 
         PLAYER_EVENT_COUNT
     };

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -460,6 +460,7 @@ public:
     void OnUpdateZone(Player* pPlayer, uint32 newZone, uint32 newArea);
     void OnMapChanged(Player* pPlayer);
     void HandleGossipSelectOption(Player* pPlayer, uint32 menuId, uint32 sender, uint32 action, const std::string& code);
+    void OnExploreNewArea(Player* pPlayer, uint32 areaId);
 
 #ifndef CLASSIC
 #ifndef TBC

--- a/PlayerHooks.cpp
+++ b/PlayerHooks.cpp
@@ -544,3 +544,11 @@ bool Eluna::OnChat(Player* pPlayer, uint32 type, uint32 lang, std::string& msg, 
     CleanUpStack(5);
     return result;
 }
+
+void Eluna::OnExploreNewArea(Player* pPlayer, uint32 areaId)
+{
+    START_HOOK(PLAYER_EVENT_ON_EXPLORE_NEW_AREA);
+    Push(pPlayer);
+    Push(areaId);
+    CallAllFunctions(PlayerEventBindings, key);
+}


### PR DESCRIPTION
A hook for when a player explores an area for the first time.

local function OnExploreNewArea(event, player, areaid)
    print(player:GetName()..' explored '..GetAreaName(areaid))
end
RegisterPlayerEvent(44, OnExploreNewArea)
