### PR TITLE
feat(Engine): add support USING_BOOST macro for AC

### DIFF
--- a/LuaEngine.cpp
+++ b/LuaEngine.cpp
@@ -32,7 +32,7 @@
 
 // Some dummy includes containing BOOST_VERSION:
 // ObjectAccessor.h Config.h Log.h
-#if !defined MANGOS && !defined AZEROTHCORE
+#if !defined MANGOS
 #define USING_BOOST
 #endif
 


### PR DESCRIPTION
## Changes Proposed:
- Remove `ace` inherited for AzerothCore

---
@Rochet2 I think you can merge this now