### PR TITLE
Fix WorldObject:SpawnCreature despawnTimer for TrinityCore

### DIFF
--- a/WorldObjectMethods.h
+++ b/WorldObjectMethods.h
@@ -832,7 +832,7 @@ namespace LuaWorldObject
         }
 #endif
 #ifdef TRINITY
-        Eluna::Push(L, obj->SummonCreature(entry, x, y, z, o, type, Seconds(despawnTimer)));
+        Eluna::Push(L, obj->SummonCreature(entry, x, y, z, o, type, Milliseconds(despawnTimer)));
 #else
         Eluna::Push(L, obj->SummonCreature(entry, x, y, z, o, type, despawnTimer));
 #endif


### PR DESCRIPTION
`TempSummon* WorldObject::SummonCreature` takes std::chrono::milliseconds as an argument, not seconds 
(unlike `GameObject* WorldObject::SummonGameObject` which takes std::chrono::seconds)

[TempSummon* WorldObject::SummonCreature(uint32 id, float x, float y, float z, float o /*= 0*/, TempSummonType despawnType /*= TEMPSUMMON_MANUAL_DESPAWN*/, Milliseconds despawnTime /*= 0s*/, bool visibleBySummonerOnly /*= false*/)](https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/blob/06136c07451ccdf8aae0418aa48568b1983d0a66/src/server/game/Entities/Object/Object.cpp#L2048)

Casting uint32 -> Seconds -> Milliseconds makes a * 1000 happen so if you wanted to spawn a creature for 5000 milliseconds you end up spawning it for 5000000 milliseconds.

Currently doing a WorldObject:SpawnCreature(..., TEMPSUMMON_TIMED_DESPAWN, 5000) in AzerothCore works as it should according to the documentation [(@param uint32 despawnTimer = 0 : despawn time in milliseconds)](https://github.com/ElunaLuaEngine/Eluna/blob/802041647b094649574ab0ae7c37601b6180802f/WorldObjectMethods.h#L752) and spawns the creature for 5 seconds but doing that in TrinityCore makes it spawn for 5000 seconds.

edit: Add that I indeed tested AC vs TC behaviour in-game on both, not just assuming so.