### PR TITLE
[WIP] Add C module support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Please see the included DOCS/LICENSE.md for more information
 #
 
-if( ${CMAKE_PROJECT_NAME} STREQUAL "MaNGOS" )
+if( ELUNA AND ${CMAKE_PROJECT_NAME} STREQUAL "MaNGOS" )
 
   if ( USE_COREPCH )
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -78,3 +78,85 @@ if( ${CMAKE_PROJECT_NAME} STREQUAL "MaNGOS" )
   install(DIRECTORY extensions DESTINATION "${BIN_DIR}/lua_scripts/")
   
 endif()
+
+# Eluna modules
+
+file(GLOB modules_list LIST_DIRECTORIES true ${CMAKE_CURRENT_SOURCE_DIR}/modules/*)
+foreach(dir ${modules_list})
+  IF(IS_DIRECTORY ${dir})
+    get_filename_component(module_name ${dir} NAME)
+    file(GLOB sources_module ${dir}/*.c ${dir}/*.h)
+
+    if( ELUNA_MODULES )
+      add_library(${module_name} MODULE
+        ${sources_module})
+      target_include_directories(${module_name}
+        PUBLIC
+          ${CMAKE_SOURCE_DIR}/dep/lualib)
+      target_link_libraries(${module_name}
+        PUBLIC
+          lualib)
+      if(UNIX)
+        set_target_properties(${module_name}
+          PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY bin/lua_scripts/modules
+            RUNTIME_OUTPUT_DIRECTORY bin/lua_scripts/modules)
+      elseif(WIN32)
+        set_target_properties(${module_name}
+          PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/lua_scripts/modules"
+            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/lua_scripts/modules")
+        if( MSVC )
+          foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+            string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+            set_target_properties(${module_name}
+              PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/lua_scripts/modules"
+                LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/lua_scripts/modules")
+          endforeach()
+        endif()
+      endif()
+      message(STATUS "Added Eluna custom module: ${dir}")
+    endif()
+
+    list(APPEND list_module_names ${module_name})
+    list(APPEND list_module_sources ${sources_module})
+    list(APPEND list_module_includes ${dir})
+  ELSE()
+    CONTINUE()
+  ENDIF()
+endforeach()
+
+# safeguard to remove module sources from all other build targets than the modules themselves
+
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()
+
+get_all_targets_recursive(all_targets ${CMAKE_SOURCE_DIR})
+foreach(target ${all_targets})
+  if (${target} IN_LIST list_module_names)
+    continue()
+  else()
+    get_target_property(_sources ${target} SOURCES)
+    if(_sources)
+      foreach(item ${list_module_sources})
+        list(REMOVE_ITEM _sources ${item})
+      endforeach()
+      set_property(TARGET ${target} PROPERTY SOURCES ${_sources})
+    endif()
+    get_target_property(_includes ${target} INCLUDE_DIRECTORIES)
+    if(_includes)
+      foreach(dir ${list_module_includes})
+        list(REMOVE_ITEM _includes ${dir})
+      endforeach()
+      set_property(TARGET ${target} PROPERTY INCLUDE_DIRECTORIES ${_includes})
+    endif()
+  endif()
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ foreach(dir ${modules_list})
     get_filename_component(module_name ${dir} NAME)
     file(GLOB sources_module ${dir}/*.c ${dir}/*.h)
 
-    if( ELUNA_MODULES and sources_module )
+    if( ELUNA_MODULES AND sources_module )
       add_library(${module_name} MODULE
         ${sources_module})
       target_include_directories(${module_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ foreach(dir ${modules_list})
     get_filename_component(module_name ${dir} NAME)
     file(GLOB sources_module ${dir}/*.c ${dir}/*.h)
 
-    if( ELUNA_MODULES )
+    if( ELUNA_MODULES and sources_module )
       add_library(${module_name} MODULE
         ${sources_module})
       target_include_directories(${module_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ file(GLOB modules_list LIST_DIRECTORIES true ${CMAKE_CURRENT_SOURCE_DIR}/modules
 foreach(dir ${modules_list})
   IF(IS_DIRECTORY ${dir})
     get_filename_component(module_name ${dir} NAME)
-    file(GLOB sources_module ${dir}/*.c ${dir}/*.h)
+    file(GLOB sources_module ${dir}/*.c ${dir}/*.cpp ${dir}/*.h ${dir}/*.hpp)
 
     if( ELUNA_MODULES AND sources_module )
       add_library(${module_name} MODULE

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -349,6 +349,18 @@ public:
      */
     void PushInstanceData(lua_State* L, ElunaInstanceAI* ai, bool incrementCounter = true);
 
+    /*
+     * Iterates through the list of loaded modules in [package.loaded]
+     * and checks whether they have a magic function called "_Unload"
+     * If so, call it.
+     *
+     * This is called on worldserver exit and is meant so that modules
+     * can exit cleanly destroying threads and saving files if need to.
+     */
+#if defined(ELUNA_MODULES)
+    void RunModuleUnloads();
+#endif
+
     void RunScripts();
     bool ShouldReload() const { return reload; }
     bool IsEnabled() const { return enabled && IsInitialized(); }

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -166,6 +166,11 @@ private:
     // lua path variable for require() function
     static std::string lua_requirepath;
 
+#if defined(ELUNA_MODULES)
+    // lua cpath variable for require() function
+    static std::string lua_requirecpath;
+#endif
+
     // A counter for lua event stacks that occur (see event_level).
     // This is used to determine whether an object belongs to the current call stack or not.
     // 0 is reserved for always belonging to the call stack

--- a/modules/example_module/example_module.c
+++ b/modules/example_module/example_module.c
@@ -1,0 +1,25 @@
+#include "lua.h"
+#include "lauxlib.h"
+
+#if defined(WIN32)
+#define MODULEAPI __declspec(dllexport) int
+#else
+#define MODULEAPI int
+#endif
+
+const char MESSAGE[] = "hello world!";
+
+int say_hello(lua_State *L) {
+    lua_pushstring(L, MESSAGE);
+    return 1;
+}
+
+static const struct luaL_Reg functions [] = {
+    {"say_hello", say_hello},
+    {NULL, NULL}
+};
+
+MODULEAPI luaopen_example_module(lua_State *L) {
+    luaL_register(L, "example_module", functions);
+    return 1;
+}

--- a/modules/example_module/example_module.c
+++ b/modules/example_module/example_module.c
@@ -14,8 +14,20 @@ int say_hello(lua_State *L) {
     return 1;
 }
 
+/*
+ * _Unload() is a magic function name which is called(if found) on every module
+ * when Eluna uninitializes(on server exit)
+ * 
+ * You do not need this, but you can use it to save files, cleanly exit threads, etc.
+ * 
+ */
+int _Unload(lua_State* L) {
+    return 0;
+}
+
 static const struct luaL_Reg functions [] = {
     {"say_hello", say_hello},
+    {"_Unload", _Unload},
     {NULL, NULL}
 };
 

--- a/modules/example_module/test_example_module.lua
+++ b/modules/example_module/test_example_module.lua
@@ -1,0 +1,6 @@
+
+require "example_module"
+
+print("Testing say_hello()")
+assert("hello world!" == example_module.say_hello())
+print(example_module.say_hello())


### PR DESCRIPTION
So as LUA natively supports extending it with C modules, with minor changes it was possible to add this functionality to Eluna too. I think this would be a great way to extend Eluna functionality with things like http requests, luasocket, discord bot apis etc. with cross-compability between cores and platforms so it would sit well with the goal and spirit of Eluna. Only minimal core changes are required (basically only check-fix CMake builds) and no existing functionality will be broken.

Pros:
* Can add new functionality without bloating the lean & clean code base of Eluna. People who don't need/want it can easily opt-out (everything is behind ELUNA_MODULES build flag in CMake)
* Modules can be created by different people in their own repos instead of pushing the changes to Eluna itself, thus making maintainability easier, codebase smaller, and let the module-makers worry about keeping their modules updated if need to be.
* C code can be used without directly patching the core itself.
* Cross-compatibility between cores, use modules in any core.
* Not suspectible to changes in cores and avoid merge conflicts
* **Modularity**

Core changes and testing:
- [x] TrinityCore https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/pull/15
- [ ] AzerothCore
- [ ] MaNGOS
- [ ] CMaNGOS
  * [x] CMaNGOS-One [Classic] https://github.com/Niam5/mangos-classic/commit/91375e414b0588a85ed04f4a6641ebd947a74127 (Thanks @Niam5) 
  * [ ] CMaNGOS-Two [TBC]
  * [ ] CMaNGOS-Three [WotLK]

Any thoughts? All feedback is welcome and appreciated and also testing for Windows/Linux builds and making the required changes if needed in cores would be helpful. Anyone who are familiar with the cores I'm not (MaNGOS, CMaNGOS) if could test this with those respective cores would be greatly appreciated.

