### PR TITLE
add unit method SetImmuneTo

### DIFF
--- a/CMangos/UnitMethods.h
+++ b/CMangos/UnitMethods.h
@@ -1601,7 +1601,7 @@ namespace LuaUnit
     int SetRooted(Eluna* E, Unit* unit)
     {
         bool apply = Eluna::CHECKVAL<bool>(E->L, 2, true);
-        
+
         unit->SetImmobilizedState(apply);
         return 0;
     }
@@ -2447,7 +2447,7 @@ namespace LuaUnit
 #endif
         return 0;
     }
-    
+
     ElunaRegister<Unit> UnitMethods[] =
     {
         // Getters
@@ -2644,6 +2644,7 @@ namespace LuaUnit
         { "RemoveCharmAuras", nullptr, METHOD_REG_NONE }, // not implemented
         { "DisableMelee", nullptr, METHOD_REG_NONE }, // not implemented
         { "SummonGuardian", nullptr, METHOD_REG_NONE }, // not implemented
+        { "SetImmuneTo", nullptr }, // not implemented
 
         { NULL, NULL, METHOD_REG_NONE }
     };

--- a/Mangos/UnitMethods.h
+++ b/Mangos/UnitMethods.h
@@ -3112,7 +3112,7 @@ namespace LuaUnit
     E->Push(summon);
     return 1;
     }*/
-    
+
     ElunaRegister<Unit> UnitMethods[] =
     {
         // Getters
@@ -3298,6 +3298,7 @@ namespace LuaUnit
         { "RemoveCharmAuras", nullptr }, // not implemented
         { "DisableMelee", nullptr }, // not implemented
         { "SummonGuardian", nullptr }, // not implemented
+        { "SetImmuneTo", nullptr }, // not implemented
 
         { NULL, NULL }
     };

--- a/TrinityCore/UnitMethods.h
+++ b/TrinityCore/UnitMethods.h
@@ -53,10 +53,10 @@ namespace LuaUnit
     * @param int32 immunity : new value for the immunity mask
     * @param bool apply = true : if true, the immunity is applied, otherwise it is removed
     */
-    int SetImmuneTo(lua_State* L, Unit* unit)
+    int SetImmuneTo(lua_State* E->L, Unit* unit)
     {
-        int32 immunity = Eluna::CHECKVAL<int32>(L, 2, true);
-        bool apply = Eluna::CHECKVAL<bool>(L, 3, true);
+        int32 immunity = Eluna::CHECKVAL<int32>(E->L, 2);
+        bool apply = Eluna::CHECKVAL<bool>(E->L, 3, true);
 
         unit->ApplySpellImmune(0, 5, immunity, apply);
         return 0;

--- a/TrinityCore/UnitMethods.h
+++ b/TrinityCore/UnitMethods.h
@@ -2629,7 +2629,7 @@ namespace LuaUnit
         { "SetStandState", &LuaUnit::SetStandState },
         { "SetInCombatWith", &LuaUnit::SetInCombatWith },
         { "ModifyPower", &LuaUnit::ModifyPower },
-        { "SetImmuneTo", &LuaUnit::SetImmuneTo}
+        { "SetImmuneTo", &LuaUnit::SetImmuneTo },
 
         // Boolean
         { "IsAlive", &LuaUnit::IsAlive },

--- a/TrinityCore/UnitMethods.h
+++ b/TrinityCore/UnitMethods.h
@@ -13,6 +13,55 @@
 namespace LuaUnit
 {
     /**
+    * Sets a mechanic immunity for the [Unit].
+    *
+    * <pre>
+    *   MECHANIC_NONE             = 0,
+    *   MECHANIC_CHARM            = 1,
+    *   MECHANIC_DISORIENTED      = 2,
+    *   MECHANIC_DISARM           = 3,
+    *   MECHANIC_DISTRACT         = 4,
+    *   MECHANIC_FEAR             = 5,
+    *   MECHANIC_GRIP             = 6,
+    *   MECHANIC_ROOT             = 7,
+    *   MECHANIC_SLOW_ATTACK      = 8,
+    *   MECHANIC_SILENCE          = 9,
+    *   MECHANIC_SLEEP            = 10,
+    *   MECHANIC_SNARE            = 11,
+    *   MECHANIC_STUN             = 12,
+    *   MECHANIC_FREEZE           = 13,
+    *   MECHANIC_KNOCKOUT         = 14,
+    *   MECHANIC_BLEED            = 15,
+    *   MECHANIC_BANDAGE          = 16,
+    *   MECHANIC_POLYMORPH        = 17,
+    *   MECHANIC_BANISH           = 18,
+    *   MECHANIC_SHIELD           = 19,
+    *   MECHANIC_SHACKLE          = 20,
+    *   MECHANIC_MOUNT            = 21,
+    *   MECHANIC_INFECTED         = 22,
+    *   MECHANIC_TURN             = 23,
+    *   MECHANIC_HORROR           = 24,
+    *   MECHANIC_INVULNERABILITY  = 25,
+    *   MECHANIC_INTERRUPT        = 26,
+    *   MECHANIC_DAZE             = 27,
+    *   MECHANIC_DISCOVERY        = 28,
+    *   MECHANIC_IMMUNE_SHIELD    = 29,     // Divine (Blessing) Shield/Protection and Ice Block
+    *   MECHANIC_SAPPED           = 30,
+    *   MECHANIC_ENRAGED          = 31
+    * </pre>
+    *
+    * @param int32 immunity : new value for the immunity mask
+    * @param bool apply = true : if true, the immunity is applied, otherwise it is removed
+    */
+    int SetImmuneTo(lua_State* L, Unit* unit)
+    {
+        int32 immunity = Eluna::CHECKVAL<int32>(L, 2, true);
+        bool apply = Eluna::CHECKVAL<bool>(L, 3, true);
+
+        unit->ApplySpellImmune(0, 5, immunity, apply);
+        return 0;
+    }
+    /**
      * The [Unit] tries to attack a given target
      *
      * @param [Unit] who : [Unit] to attack
@@ -2500,7 +2549,7 @@ namespace LuaUnit
     E->Push(summon);
     return 1;
     }*/
-    
+
     ElunaRegister<Unit> UnitMethods[] =
     {
         // Getters
@@ -2580,6 +2629,7 @@ namespace LuaUnit
         { "SetStandState", &LuaUnit::SetStandState },
         { "SetInCombatWith", &LuaUnit::SetInCombatWith },
         { "ModifyPower", &LuaUnit::ModifyPower },
+        { "SetImmuneTo", &LuaUnit::SetImmuneTo}
 
         // Boolean
         { "IsAlive", &LuaUnit::IsAlive },

--- a/TrinityCore/UnitMethods.h
+++ b/TrinityCore/UnitMethods.h
@@ -53,7 +53,7 @@ namespace LuaUnit
     * @param int32 immunity : new value for the immunity mask
     * @param bool apply = true : if true, the immunity is applied, otherwise it is removed
     */
-    int SetImmuneTo(lua_State* E->L, Unit* unit)
+    int SetImmuneTo(Eluna* E, Unit* unit)
     {
         int32 immunity = Eluna::CHECKVAL<int32>(E->L, 2);
         bool apply = Eluna::CHECKVAL<bool>(E->L, 3, true);

--- a/VMangos/UnitMethods.h
+++ b/VMangos/UnitMethods.h
@@ -2972,7 +2972,7 @@ namespace LuaUnit
     Eluna::Push(L, summon);
     return 1;
     }*/
-    
+
     ElunaRegister<Unit> UnitMethods[] =
     {
         // Getters
@@ -3158,6 +3158,7 @@ namespace LuaUnit
         { "RemoveCharmAuras", nullptr }, // not implemented
         { "DisableMelee", nullptr }, // not implemented
         { "SummonGuardian", nullptr }, // not implemented
+        { "SetImmuneTo", nullptr }, // not implemented
 
         { NULL, NULL }
     };


### PR DESCRIPTION
Adds a new method to add and remove mechanic immunities. See https://github.com/azerothcore/mod-eluna/pull/167

Tested on AC with:
```lua
local function ImmunityOff(eventid, delay, repeats, creature)
    creature:SetImmuneTo(26, false)
    creature:SendUnitSay("I am interruptable now.", 0)
end

local function Cast(eventid, delay, repeats, creature)
    creature:CastSpell(creature, 57775, false)
end

local function EnterCombat(event, creature, target)
    creature:SetImmuneTo(26, true)
    creature:SendUnitSay("You can not interrupt me.", 0)
    
    creature:RegisterEvent(Cast, 5500, 0)
    creature:RegisterEvent(ImmunityOff, 15000, 1)
end

local function LeaveCombat(event, creature)
    creature:RemoveEvents()
end

RegisterCreatureEvent(113, 1, EnterCombat)
RegisterCreatureEvent(113, 2, LeaveCombat) -- OnLeaveCombat
RegisterCreatureEvent(113, 4, LeaveCombat) -- OnDied
```

![image](https://github.com/azerothcore/mod-eluna/assets/71938210/dc9caa2b-1817-40d3-a8e0-2daf178070f6)
