### PR TITLE
Improved memory allocation patterns for ElunaObject and LuaVal

### DIFF
--- a/ElunaTemplate.h
+++ b/ElunaTemplate.h
@@ -334,14 +334,14 @@ public:
         }
 
         // Create new userdata
-        ElunaObject** ptrHold = static_cast<ElunaObject**>(lua_newuserdata(L, sizeof(ElunaObject*)));
-        if (!ptrHold)
+        ElunaObject* elunaObject = static_cast<ElunaObject*>(lua_newuserdata(L, sizeof(ElunaObject)));
+        if (!elunaObject)
         {
             ELUNA_LOG_ERROR("%s could not create new userdata", tname);
             lua_pushnil(L);
             return 1;
         }
-        *ptrHold = new ElunaObject(E, const_cast<T*>(obj), manageMemory);
+        new (elunaObject) ElunaObject(E, const_cast<T*>(obj), manageMemory);
 
         // Set metatable for it
         lua_pushstring(L, tname);
@@ -431,7 +431,7 @@ public:
         ElunaObject* obj = E->CHECKOBJ<ElunaObject>(1, false);
         if (obj && manageMemory)
             delete static_cast<T*>(obj->GetObj());
-        delete obj;
+        obj->~ElunaObject();
         return 0;
     }
 

--- a/LuaEngine.cpp
+++ b/LuaEngine.cpp
@@ -697,19 +697,19 @@ ElunaObject* Eluna::CHECKTYPE(int narg, const char* tname, bool error)
         return NULL;
     }
 
-    ElunaObject** ptrHold = static_cast<ElunaObject**>(lua_touserdata(L, narg));
+    ElunaObject* elunaObject = static_cast<ElunaObject*>(lua_touserdata(L, narg));
 
-    if (!ptrHold || (tname && (*ptrHold)->GetTypeName() != tname))
+    if (!elunaObject || (tname && elunaObject->GetTypeName() != tname))
     {
         if (error)
         {
             char buff[256];
-            snprintf(buff, 256, "bad argument : %s expected, got %s", tname ? tname : "ElunaObject", ptrHold ? (*ptrHold)->GetTypeName() : luaL_typename(L, narg));
+            snprintf(buff, 256, "bad argument : %s expected, got %s", tname ? tname : "ElunaObject", elunaObject ? elunaObject->GetTypeName() : luaL_typename(L, narg));
             luaL_argerror(L, narg, buff);
         }
         return NULL;
     }
-    return *ptrHold;
+    return elunaObject;
 }
 
 template<typename K>

--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -47,7 +47,7 @@ template<> int ElunaTemplate<Vehicle>::CollectGarbage(lua_State* L)
 
     // Get object pointer (and check type, no error)
     ElunaObject* obj = E->CHECKOBJ<ElunaObject>(1, false);
-    delete obj;
+    obj->~ElunaObject();
     return 0;
 }
 #endif

--- a/LuaValue.cpp
+++ b/LuaValue.cpp
@@ -38,19 +38,16 @@ extern "C"
 }
 
 LuaVal* LuaVal::GetLuaVal(lua_State* L, int index) {
-    if (LuaVal** ptr = static_cast<LuaVal**>(luaL_testudata(L, index, LUAVAL_MT_NAME)))
-        return *ptr;
-    return nullptr;
+    return static_cast<LuaVal*>(luaL_testudata(L, index, LUAVAL_MT_NAME));
 }
 
 LuaVal* LuaVal::GetCheckLuaVal(lua_State* L, int index) {
-    LuaVal** ptr = static_cast<LuaVal**>(luaL_checkudata(L, index, LUAVAL_MT_NAME));
-    return *ptr;
+    return static_cast<LuaVal*>(luaL_checkudata(L, index, LUAVAL_MT_NAME));
 }
 
 int LuaVal::PushLuaVal(lua_State* L, LuaVal const& lv) {
-    LuaVal** ud = static_cast<LuaVal**>(lua_newuserdata(L, sizeof(LuaVal*)));
-    *ud = new LuaVal(lv.reference());
+    LuaVal* ud = static_cast<LuaVal*>(lua_newuserdata(L, sizeof(LuaVal)));
+    new (ud) LuaVal(lv.reference());
     luaL_setmetatable(L, LUAVAL_MT_NAME);
     return 1;
 }
@@ -161,7 +158,7 @@ int LuaVal::lua_to_string(lua_State* L)
 int LuaVal::lua_gc(lua_State* L)
 {
     LuaVal* self = GetCheckLuaVal(L, 1);
-    delete self;
+    self->~LuaVal();
     return 0;
 }
 

--- a/LuaValue.cpp
+++ b/LuaValue.cpp
@@ -78,13 +78,13 @@ void LuaVal::Register(lua_State* L) {
 int LuaVal::lua_get(lua_State* L) {
     LuaVal* self = GetCheckLuaVal(L, 1);
     int arguments = std::max(2, lua_gettop(L));
-    WrappedMap const* p = std::get_if<WrappedMap>(&*self->v);
+    WrappedMap const* p = std::get_if<WrappedMap>(&self->v);
     if (!p)
         luaL_argerror(L, 1, "trying to index a non-table LuaVal");
     for (int i = 2; i <= arguments; ++i) {
         auto& map = (*p);
         auto klv = AsLuaVal(L, i);
-        if (std::holds_alternative<NIL>(*klv.v))
+        if (std::holds_alternative<NIL>(klv.v))
             luaL_argerror(L, i, "trying to use nil as key");
         auto it = map->find(klv);
         if (it == map->end()) {
@@ -97,7 +97,7 @@ int LuaVal::lua_get(lua_State* L) {
             auto& val = it->second;
             return val.asObject(L);
         }
-        p = std::get_if<WrappedMap>(&*it->second.v);
+        p = std::get_if<WrappedMap>(&it->second.v);
         if (!p)
             luaL_argerror(L, i, "trying to index a non-table LuaVal");
     }
@@ -108,13 +108,13 @@ int LuaVal::lua_get(lua_State* L) {
 int LuaVal::lua_set(lua_State* L) {
     LuaVal* self = GetCheckLuaVal(L, 1);
     int arguments = std::max(3, lua_gettop(L));
-    WrappedMap const* p = std::get_if<WrappedMap>(&*self->v);
+    WrappedMap const* p = std::get_if<WrappedMap>(&self->v);
     if (!p)
         luaL_argerror(L, 1, "trying to index a non-table LuaVal");
     for (int i = 2; i <= arguments - 2; ++i) {
         auto& map = (*p);
         auto klv = AsLuaVal(L, i);
-        if (std::holds_alternative<NIL>(*klv.v))
+        if (std::holds_alternative<NIL>(klv.v))
             luaL_argerror(L, i, "trying to use nil as key");
         auto it = map->find(klv);
         if (it == map->end()) {
@@ -123,15 +123,15 @@ int LuaVal::lua_set(lua_State* L) {
             }
             break;
         }
-        p = std::get_if<WrappedMap>(&*it->second.v);
+        p = std::get_if<WrappedMap>(&it->second.v);
         if (!p)
             luaL_argerror(L, i, "trying to index a non-table LuaVal");
     }
     auto kk = AsLuaVal(L, arguments - 1);
     auto vv = AsLuaVal(L, arguments);
-    if (std::holds_alternative<NIL>(*kk.v))
+    if (std::holds_alternative<NIL>(kk.v))
         luaL_argerror(L, arguments - 1, "trying to use nil as key");
-    if (std::holds_alternative<NIL>(*vv.v)) {
+    if (std::holds_alternative<NIL>(vv.v)) {
         (**p).erase(kk);
     }
     else {
@@ -170,8 +170,8 @@ int LuaVal::asObject(lua_State* L) const
             lua_pushnil(L);
             return 1;
         }
-        else if constexpr (std::is_same_v<T, std::unique_ptr<std::string>>) {
-            lua_pushlstring(L, arg->c_str(), arg->size());
+        else if constexpr (std::is_same_v<T, std::string>) {
+            lua_pushlstring(L, arg.c_str(), arg.size());
             return 1;
         }
         else if constexpr (std::is_same_v<T, WrappedMap>) {
@@ -188,12 +188,12 @@ int LuaVal::asObject(lua_State* L) const
         else {
             static_assert(always_false<T>::value, "non-exhaustive visitor!");
         }
-        }, *v);
+        }, v);
 }
 
 int LuaVal::asLua(lua_State* L, unsigned int depth) const
 {
-    WrappedMap const* p = std::get_if<WrappedMap>(&*v);
+    WrappedMap const* p = std::get_if<WrappedMap>(&v);
     if (p)
     {
         lua_newtable(L);
@@ -262,7 +262,7 @@ LuaVal LuaVal::FromTable(lua_State* L, int index)
 {
     // Assumed we know index is a table already
     LuaVal m({});
-    auto& t = std::get<WrappedMap>(*m.v);
+    auto& t = std::get<WrappedMap>(m.v);
     int top = lua_gettop(L);
     lua_pushnil(L);
     while (lua_next(L, index) != 0) {
@@ -274,9 +274,5 @@ LuaVal LuaVal::FromTable(lua_State* L, int index)
 
 size_t LuaValHash(LuaVal const& k)
 {
-    const std::unique_ptr<std::string>* pval = std::get_if<std::unique_ptr<std::string>>(&*k.v);
-    if (pval) {
-        return std::hash<std::string>{}(**pval);
-    }
-    return std::hash<LuaVal::LuaValVariant>{}(*k.v);
+    return std::hash<LuaVal::LuaValVariant>{}(k.v);
 }

--- a/LuaValue.cpp
+++ b/LuaValue.cpp
@@ -140,11 +140,13 @@ int LuaVal::lua_set(lua_State* L) {
     return 0;
 }
 
-std::string LuaVal::tostring(void* ptr)
+std::string LuaVal::to_string_map(MapType const* ptr)
 {
-    char arr[128];
-    snprintf(arr, 128, "LuaVal: %p", ptr);
-    return arr;
+    std::string out = "[\n";
+    for (std::pair<const LuaVal, LuaVal> const& pair : *ptr)
+        out += "  { key: " + pair.first.to_string() + ", value: " + pair.second.to_string() + " },\n";
+    out += ']';
+    return out;
 }
 
 int LuaVal::lua_to_string(lua_State* L)

--- a/LuaValue.h
+++ b/LuaValue.h
@@ -67,7 +67,7 @@ public:
     static int lua_get(lua_State* L);
     static int lua_set(lua_State* L);
 
-    static std::string tostring(void* ptr);
+    static std::string to_string_map(MapType const* ptr);
     int asObject(lua_State* L) const;
     int asLua(lua_State* L, unsigned int depth) const;
     static LuaVal AsLuaVal(lua_State* L, int index);
@@ -101,7 +101,7 @@ public:
             else if constexpr (std::is_same_v<T, std::string>)
                 return arg;
             else if constexpr (std::is_same_v<T, WrappedMap>)
-                return tostring(arg.get());
+                return LuaVal::to_string_map(arg.get());
             else if constexpr (std::is_same_v<T, bool>)
                 return arg ? "true" : "false";
             else if constexpr (std::is_same_v<T, double>)

--- a/LuaValue.h
+++ b/LuaValue.h
@@ -62,7 +62,7 @@ public:
     typedef std::monostate NIL;
     template<class T> struct always_false : std::false_type {};
     typedef std::shared_ptr<MapType> WrappedMap;
-    typedef std::variant<NIL, std::unique_ptr<std::string>, WrappedMap, bool, double> LuaValVariant;
+    typedef std::variant<NIL, std::string, WrappedMap, bool, double> LuaValVariant;
 
     static int lua_get(lua_State* L);
     static int lua_set(lua_State* L);
@@ -84,24 +84,12 @@ public:
 
     bool operator<(LuaVal const& b) const
     {
-        if (v->index() == b.v->index()) {
-            const std::unique_ptr<std::string>* pval = std::get_if<std::unique_ptr<std::string>>(&*v);
-            if (pval) {
-                return **pval < **std::get_if<std::unique_ptr<std::string>>(&*b.v);
-            }
-        }
-        return *v < *b.v;
+        return v < b.v;
     }
 
     bool operator==(LuaVal const& b) const
     {
-        if (v->index() == b.v->index()) {
-            const std::unique_ptr<std::string>* pval = std::get_if<std::unique_ptr<std::string>>(&*v);
-            if (pval) {
-                return **pval == **std::get_if<std::unique_ptr<std::string>>(&*b.v);
-            }
-        }
-        return *v == *b.v;
+        return v == b.v;
     }
 
     std::string to_string() const
@@ -110,8 +98,8 @@ public:
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, NIL>)
                 return "nil";
-            else if constexpr (std::is_same_v<T, std::unique_ptr<std::string>>)
-                return *arg;
+            else if constexpr (std::is_same_v<T, std::string>)
+                return arg;
             else if constexpr (std::is_same_v<T, WrappedMap>)
                 return tostring(arg.get());
             else if constexpr (std::is_same_v<T, bool>)
@@ -120,60 +108,46 @@ public:
                 return std::to_string(arg);
             else
                 static_assert(always_false<T>::value, "non-exhaustive visitor!");
-            }, *v);
+            }, v);
     }
 
-    LuaVal() : v(std::make_unique<LuaValVariant>()) {}
-    LuaVal(std::string const& s) : v(std::make_unique<LuaValVariant>(std::make_unique<std::string>(s))) {}
-    LuaVal(bool b) : v(std::make_unique<LuaValVariant>(b)) {}
-    LuaVal(double d) : v(std::make_unique<LuaValVariant>(d)) {}
-    LuaVal(MapType const& t) : v(std::make_unique<LuaValVariant>(std::make_shared<MapType>(t))) {}
-    LuaVal(std::initializer_list<std::pair<const LuaVal, LuaVal> /* MapType::value_type */> const& l) : v(std::make_unique<LuaValVariant>(std::make_shared<MapType>(l))) {}
+    LuaVal() : v() {}
+    LuaVal(std::string const& s) : v(s) {}
+    LuaVal(bool b) : v(b) {}
+    LuaVal(double d) : v(d) {}
+    LuaVal(MapType const& t) : v(std::make_shared<MapType>(t)) {}
+    LuaVal(std::initializer_list<std::pair<const LuaVal, LuaVal> /* MapType::value_type */> const& l) : v(std::make_shared<MapType>(l)) {}
 
-    LuaVal(LuaVal&& b) : v(std::move(b.v)) {
+    LuaVal(LuaVal&& b) noexcept : v(std::move(b.v)) {
     }
-    LuaVal(const LuaVal& b) : v(std::make_unique<LuaValVariant>(std::visit([&](auto&& arg) -> LuaValVariant {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, std::unique_ptr<std::string>>)
-            return std::make_unique<std::string>(*arg);
-        else if constexpr (std::is_same_v<T, WrappedMap>)
-            return std::make_shared<MapType>(*arg);
-        else
-            return arg;
-        }, *b.v))) {
+    LuaVal(const LuaVal& b) : v(b.v) {
     }
     ~LuaVal() {
     }
-    LuaVal& operator=(LuaVal&& b) {
+    LuaVal& operator=(LuaVal&& b) noexcept
+    {
         v = std::move(b.v);
         return *this;
     }
     LuaVal& operator=(const LuaVal& b) {
-        v = std::make_unique<LuaValVariant>(std::visit([&](auto&& arg) -> LuaValVariant {
-            using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, std::unique_ptr<std::string>>)
-                return std::make_unique<std::string>(*arg);
-            else if constexpr (std::is_same_v<T, WrappedMap>)
-                return std::make_shared<MapType>(*arg);
-            else
-                return arg;
-            }, *b.v));
+        v = b.v;
         return *this;
     }
     LuaVal clone() const {
-        return *this;
-    }
-    LuaVal reference() const {
         LuaVal lv;
-        lv.v = std::make_unique<LuaValVariant>(std::visit([&](auto&& arg) -> LuaValVariant {
+        lv.v = std::visit([&](auto&& arg) -> LuaValVariant
+        {
             using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, std::unique_ptr<std::string>>)
-                return std::make_unique<std::string>(*arg);
+            if constexpr (std::is_same_v<T, WrappedMap>)
+                return std::make_shared<MapType>(*arg);
             else
                 return arg;
-            }, *v));
+        }, v);
         return lv;
     }
+    LuaVal reference() const {
+        return *this;
+    }
 
-    std::unique_ptr<LuaValVariant> v;
+    LuaValVariant v;
 };


### PR DESCRIPTION
* Improved memory allocation patterns for ElunaObject and LuaVal (one alloc per call instead of two)
* Reworked LuaVal internals to remove dynamic allocation for variant and string, deep clones are now only done explicitly by `clone()` member
* Improve __tostring for LuaVal for WrappedMap case