### PR TITLE
Fix error target_compile_definitions on Cmake with Luajit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ elseif(WIN32)
 endif()
 
 # Add Lua compatibility definition
-target_compile_definitions(lualib PUBLIC LUA_COMPAT_MODULE)
+if(NOT TARGET lualib) 
+  target_compile_definitions(lualib PUBLIC LUA_COMPAT_MODULE) 
+endif()
 
 # Collect module directories
 file(GLOB_RECURSE modules_list LIST_DIRECTORIES true ${MODULES_DIR}/*)


### PR DESCRIPTION
Issue: target_compile_definitions(lualib PUBLIC LUA_COMPAT_MODULE) results in a CMake error when running with luajit.

Solution: The proposed solution is to guard this definition with a condition to ensure lualib isn't an IMPORTED target before adding the definition.