### PR TITLE
Removed additional indirection when pushing 64 bit integers, ObjectGuids, query results and WorldPackets

### DIFF
--- a/CMangos/ElunaQueryMethods.h
+++ b/CMangos/ElunaQueryMethods.h
@@ -7,7 +7,7 @@
 #ifndef QUERYMETHODS_H
 #define QUERYMETHODS_H
 
-#define RESULT  result
+#define RESULT  (*result)
 
 /***
  * The result of a database query.

--- a/CMangos/GlobalMethods.h
+++ b/CMangos/GlobalMethods.h
@@ -403,10 +403,10 @@ namespace LuaGlobalFunctions
      * Low GUID is an ID to distinct the objects of the same type.
      *
      * [Player] and [Creature] for example can have the same low GUID but not GUID.
-     * 
+     *
      * On TrinityCore all low GUIDs are different for all objects of the same type.
      * For example creatures in instances are assigned new GUIDs when the Map is created.
-     * 
+     *
      * On MaNGOS and cMaNGOS low GUIDs are unique only on the same map.
      * For example creatures in instances use the same low GUID assigned for that spawn in the database.
      * This is why to identify a creature you have to know the instanceId and low GUID. See [Map:GetIntstanceId]
@@ -1305,9 +1305,12 @@ namespace LuaGlobalFunctions
     {
         const char* query = E->CHECKVAL<const char*>(1);
 
-        ElunaQuery* result = WorldDatabase.QueryNamed(query);
+        QueryNamedResult* result = WorldDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -1409,7 +1412,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = CharacterDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -1491,7 +1497,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = LoginDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -2249,7 +2258,7 @@ namespace LuaGlobalFunctions
 
     /**
      * Adds a taxi path to a specified map, returns the used pathId.
-     * 
+     *
      * Note that the first taxi point needs to be near the player when he starts the taxi path.
      * The function should also be used only **once** per path added so use it on server startup for example.
      *
@@ -3170,7 +3179,7 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
-    
+
     ElunaGlobal::ElunaRegister GlobalMethods[] =
     {
         // Hooks

--- a/ElunaUtility.h
+++ b/ElunaUtility.h
@@ -74,7 +74,7 @@ typedef QueryResult ElunaQuery;
 #define ELUNA_LOG_ERROR(...)    LOG_ERROR("eluna", __VA_ARGS__);
 #define ELUNA_LOG_DEBUG(...)    LOG_DEBUG("eluna", __VA_ARGS__);
 #elif VMANGOS
-typedef QueryNamedResult ElunaQuery;
+typedef std::shared_ptr<QueryNamedResult> ElunaQuery;
 #define ASSERT                  MANGOS_ASSERT
 #define ELUNA_LOG_INFO(...)     sLog.Out(LOG_ELUNA, LOG_LVL_BASIC,__VA_ARGS__);
 #define ELUNA_LOG_ERROR(...)    sLog.Out(LOG_ELUNA, LOG_LVL_ERROR,__VA_ARGS__);
@@ -84,7 +84,7 @@ typedef QueryNamedResult ElunaQuery;
 #define GetItemTemplate         GetItemPrototype
 #define GetTemplate             GetProto
 #else
-typedef QueryNamedResult ElunaQuery;
+typedef std::shared_ptr<QueryNamedResult> ElunaQuery;
 #define ASSERT                  MANGOS_ASSERT
 #define ELUNA_LOG_INFO(...)     sLog.outString(__VA_ARGS__);
 #define ELUNA_LOG_ERROR(...)    sLog.outErrorEluna(__VA_ARGS__);

--- a/InstanceHooks.cpp
+++ b/InstanceHooks.cpp
@@ -20,7 +20,7 @@ using namespace Hooks;
     if (!MapEventBindings->HasBindingsFor(mapKey) && !InstanceEventBindings->HasBindingsFor(instanceKey))\
         return;\
     PushInstanceData(AI);\
-    HookPush(AI->instance)
+    HookPush<Map>(AI->instance)
 
 #define START_HOOK_WITH_RETVAL(EVENT, AI, RETVAL) \
     auto mapKey = EntryKey<InstanceEvents>(EVENT, AI->instance->GetId());\
@@ -28,7 +28,7 @@ using namespace Hooks;
     if (!MapEventBindings->HasBindingsFor(mapKey) && !InstanceEventBindings->HasBindingsFor(instanceKey))\
         return RETVAL;\
     PushInstanceData(AI);\
-    HookPush(AI->instance)
+    HookPush<Map>(AI->instance)
 
 void Eluna::OnInitialize(ElunaInstanceAI* ai)
 {

--- a/LuaEngine.cpp
+++ b/LuaEngine.cpp
@@ -423,11 +423,13 @@ void Eluna::Push()
 }
 void Eluna::Push(const long long l)
 {
-    ElunaTemplate<long long>::Push(this, new long long(l));
+    // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
+    ElunaTemplate<long long>::Push(this, &l);
 }
 void Eluna::Push(const unsigned long long l)
 {
-    ElunaTemplate<unsigned long long>::Push(this, new unsigned long long(l));
+    // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
+    ElunaTemplate<unsigned long long>::Push(this, &l);
 }
 void Eluna::Push(const long l)
 {
@@ -544,7 +546,8 @@ void Eluna::Push(Object const* obj)
 }
 void Eluna::Push(ObjectGuid const guid)
 {
-    ElunaTemplate<unsigned long long>::Push(this, new unsigned long long(guid.GetRawValue()));
+    // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
+    ElunaTemplate<ObjectGuid>::Push(this, &guid);
 }
 
 static int CheckIntegerRange(lua_State* luastate, int narg, int min, int max)
@@ -650,7 +653,8 @@ template<> unsigned long Eluna::CHECKVAL<unsigned long>(int narg)
 }
 template<> ObjectGuid Eluna::CHECKVAL<ObjectGuid>(int narg)
 {
-    return ObjectGuid(uint64((CHECKVAL<unsigned long long>(narg))));
+    ObjectGuid* guid = CHECKOBJ<ObjectGuid>(narg, true);
+    return guid ? *guid : ObjectGuid();
 }
 
 template<> Object* Eluna::CHECKOBJ<Object>(int narg, bool error)

--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -37,21 +37,6 @@ extern "C"
 #include "VehicleMethods.h"
 #include "BattleGroundMethods.h"
 
-#if (!defined(TBC) && !defined(CLASSIC))
-// fix compile error about accessing vehicle destructor
-template<> int ElunaTemplate<Vehicle>::CollectGarbage(lua_State* L)
-{
-    ASSERT(!manageMemory);
-
-    Eluna* E = Eluna::GetEluna(L);
-
-    // Get object pointer (and check type, no error)
-    ElunaObject* obj = E->CHECKOBJ<ElunaObject>(1, false);
-    obj->~ElunaObject();
-    return 0;
-}
-#endif
-
 // Template by Mud from http://stackoverflow.com/questions/4484437/lua-integer-type/4485511#4485511
 template<> int ElunaTemplate<unsigned long long>::Add(lua_State* L) { Eluna* E = Eluna::GetEluna(L); E->Push(E->CHECKVAL<unsigned long long>(1) + E->CHECKVAL<unsigned long long>(2)); return 1; }
 template<> int ElunaTemplate<unsigned long long>::Substract(lua_State* L) { Eluna* E = Eluna::GetEluna(L); E->Push(E->CHECKVAL<unsigned long long>(1) - E->CHECKVAL<unsigned long long>(2)); return 1; }
@@ -102,6 +87,18 @@ template<> int ElunaTemplate<long long>::ToString(lua_State* L)
     std::ostringstream ss;
     ss << l;
     E->Push(ss.str());
+    return 1;
+}
+
+template<> int ElunaTemplate<ObjectGuid>::Equal(lua_State* L) { Eluna* E = Eluna::GetEluna(L); E->Push(E->CHECKVAL<ObjectGuid>(1) == E->CHECKVAL<ObjectGuid>(2)); return 1; }
+template<> int ElunaTemplate<ObjectGuid>::ToString(lua_State* L)
+{
+    Eluna* E = Eluna::GetEluna(L);
+#if defined(TRINITY)
+    E->Push(E->CHECKVAL<ObjectGuid>(1).ToString());
+#else
+    E->Push(E->CHECKVAL<ObjectGuid>(1).GetString());
+#endif
     return 1;
 }
 
@@ -175,15 +172,17 @@ void RegisterFunctions(Eluna* E)
     ElunaTemplate<BattleGround>::Register(E, "BattleGround");
     ElunaTemplate<BattleGround>::SetMethods(E, LuaBattleGround::BattleGroundMethods);
 
-    ElunaTemplate<WorldPacket>::Register(E, "WorldPacket", true);
+    ElunaTemplate<WorldPacket>::Register(E, "WorldPacket");
     ElunaTemplate<WorldPacket>::SetMethods(E, LuaPacket::PacketMethods);
 
-    ElunaTemplate<ElunaQuery>::Register(E, "ElunaQuery", true);
+    ElunaTemplate<ElunaQuery>::Register(E, "ElunaQuery");
     ElunaTemplate<ElunaQuery>::SetMethods(E, LuaQuery::QueryMethods);
 
-    ElunaTemplate<long long>::Register(E, "long long", true);
+    ElunaTemplate<long long>::Register(E, "long long");
 
-    ElunaTemplate<unsigned long long>::Register(E, "unsigned long long", true);
+    ElunaTemplate<unsigned long long>::Register(E, "unsigned long long");
+
+    ElunaTemplate<ObjectGuid>::Register(E, "ObjectGuid");
 
     LuaVal::Register(E->L);
 }

--- a/Mangos/ElunaQueryMethods.h
+++ b/Mangos/ElunaQueryMethods.h
@@ -7,7 +7,7 @@
 #ifndef QUERYMETHODS_H
 #define QUERYMETHODS_H
 
-#define RESULT  result
+#define RESULT  (*result)
 
 /***
  * The result of a database query.

--- a/Mangos/GlobalMethods.h
+++ b/Mangos/GlobalMethods.h
@@ -347,10 +347,10 @@ namespace LuaGlobalFunctions
      * Low GUID is an ID to distinct the objects of the same type.
      *
      * [Player] and [Creature] for example can have the same low GUID but not GUID.
-     * 
+     *
      * On TrinityCore all low GUIDs are different for all objects of the same type.
      * For example creatures in instances are assigned new GUIDs when the Map is created.
-     * 
+     *
      * On MaNGOS and cMaNGOS low GUIDs are unique only on the same map.
      * For example creatures in instances use the same low GUID assigned for that spawn in the database.
      * This is why to identify a creature you have to know the instanceId and low GUID. See [Map:GetIntstanceId]
@@ -1233,9 +1233,12 @@ namespace LuaGlobalFunctions
     {
         const char* query = E->CHECKVAL<const char*>(1);
 
-        ElunaQuery* result = WorldDatabase.QueryNamed(query);
+        QueryNamedResult* result = WorldDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
 
@@ -1279,7 +1282,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = CharacterDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
 
@@ -1323,7 +1329,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = LoginDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
 
@@ -2015,7 +2024,7 @@ namespace LuaGlobalFunctions
 
     /**
      * Adds a taxi path to a specified map, returns the used pathId.
-     * 
+     *
      * Note that the first taxi point needs to be near the player when he starts the taxi path.
      * The function should also be used only **once** per path added so use it on server startup for example.
      *
@@ -2913,7 +2922,7 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
-    
+
     ElunaGlobal::ElunaRegister GlobalMethods[] =
     {
         // Hooks

--- a/PacketHooks.cpp
+++ b/PacketHooks.cpp
@@ -36,7 +36,7 @@ bool Eluna::OnPacketSend(WorldSession* session, const WorldPacket& packet)
 void Eluna::OnPacketSendAny(Player* player, const WorldPacket& packet, bool& result)
 {
     START_HOOK_SERVER(SERVER_EVENT_ON_PACKET_SEND);
-    HookPush(new WorldPacket(packet));
+    HookPush(&packet); // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
     HookPush(player);
     int n = SetupStack(ServerEventBindings, key, 2);
 
@@ -56,7 +56,7 @@ void Eluna::OnPacketSendAny(Player* player, const WorldPacket& packet, bool& res
 void Eluna::OnPacketSendOne(Player* player, const WorldPacket& packet, bool& result)
 {
     START_HOOK_PACKET(PACKET_EVENT_ON_PACKET_SEND, packet.GetOpcode());
-    HookPush(new WorldPacket(packet));
+    HookPush(&packet); // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
     HookPush(player);
     int n = SetupStack(PacketEventBindings, key, 2);
 
@@ -87,7 +87,7 @@ bool Eluna::OnPacketReceive(WorldSession* session, WorldPacket& packet)
 void Eluna::OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result)
 {
     START_HOOK_SERVER(SERVER_EVENT_ON_PACKET_RECEIVE);
-    HookPush(new WorldPacket(packet));
+    HookPush(&packet); // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
     HookPush(player);
     int n = SetupStack(ServerEventBindings, key, 2);
 
@@ -101,7 +101,7 @@ void Eluna::OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result
         if (lua_isuserdata(L, r + 1))
             if (WorldPacket* data = CHECKOBJ<WorldPacket>(r + 1, false))
             {
-#ifdef VMANGOS
+#if defined(TRINITY) || defined(VMANGOS)
                 packet = std::move(*data);
 #else
                 packet = *data;
@@ -117,7 +117,7 @@ void Eluna::OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result
 void Eluna::OnPacketReceiveOne(Player* player, WorldPacket& packet, bool& result)
 {
     START_HOOK_PACKET(PACKET_EVENT_ON_PACKET_RECEIVE, packet.GetOpcode());
-    HookPush(new WorldPacket(packet));
+    HookPush(&packet); // pushing pointer to local is fine, a copy of value will be stored, not pointer itself
     HookPush(player);
     int n = SetupStack(PacketEventBindings, key, 2);
 
@@ -131,7 +131,7 @@ void Eluna::OnPacketReceiveOne(Player* player, WorldPacket& packet, bool& result
         if (lua_isuserdata(L, r + 1))
             if (WorldPacket* data = CHECKOBJ<WorldPacket>(r + 1, false))
             {
-#ifdef VMANGOS
+#if defined(TRINITY) || defined(VMANGOS)
                 packet = std::move(*data);
 #else
                 packet = *data;

--- a/ServerHooks.cpp
+++ b/ServerHooks.cpp
@@ -115,7 +115,7 @@ bool Eluna::OnAreaTrigger(Player* pPlayer, AreaTriggerEntry const* pTrigger)
     HookPush(pTrigger->entry);
 #else
     HookPush(pTrigger->id);
-    
+
 #endif
     return CallAllFunctionsBool(ServerEventBindings, key);
 }

--- a/TrinityCore/AuraMethods.h
+++ b/TrinityCore/AuraMethods.h
@@ -168,7 +168,7 @@ namespace LuaAura
         E->CHECKOBJ<ElunaObject>(1)->Invalidate();
         return 0;
     }
-    
+
     ElunaRegister<Aura> AuraMethods[] =
     {
         // Getters

--- a/TrinityCore/GameObjectMethods.h
+++ b/TrinityCore/GameObjectMethods.h
@@ -316,7 +316,7 @@ namespace LuaGameObject
         go->SetRespawnTime(respawn);
         return 0;
     }
-    
+
     ElunaRegister<GameObject> GameObjectMethods[] =
     {
         // Getters

--- a/TrinityCore/GlobalMethods.h
+++ b/TrinityCore/GlobalMethods.h
@@ -137,7 +137,7 @@ namespace LuaGlobalFunctions
      * Finds and Returns [Player] by guid if found
      *
      * In multistate, this method is only available in the WORLD state
-     * 
+     *
      * @param ObjectGuid guid : guid of the [Player], you can get it with [Object:GetGUID]
      * @return [Player] player
      */
@@ -289,7 +289,7 @@ namespace LuaGlobalFunctions
      * Returns a [Map] by ID.
      *
      * In multistate, this method is only available in the WORLD state
-     * 
+     *
      * @param uint32 mapId : see [Map.dbc](https://github.com/cmangos/issues/wiki/Map.dbc)
      * @param uint32 instanceId = 0 : required if the map is an instance, otherwise don't pass anything
      * @return [Map] map : the Map, or `nil` if it doesn't exist
@@ -407,10 +407,10 @@ namespace LuaGlobalFunctions
      * Low GUID is an ID to distinct the objects of the same type.
      *
      * [Player] and [Creature] for example can have the same low GUID but not GUID.
-     * 
+     *
      * On TrinityCore all low GUIDs are different for all objects of the same type.
      * For example creatures in instances are assigned new GUIDs when the Map is created.
-     * 
+     *
      * On MaNGOS and cMaNGOS low GUIDs are unique only on the same map.
      * For example creatures in instances use the same low GUID assigned for that spawn in the database.
      * This is why to identify a creature you have to know the instanceId and low GUID. See [Map:GetIntstanceId]
@@ -1347,7 +1347,7 @@ namespace LuaGlobalFunctions
 
         ElunaQuery result = WorldDatabase.Query(query);
         if (result)
-            E->Push(new ElunaQuery(result));
+            E->Push(&result);
         else
             E->Push();
 
@@ -1391,7 +1391,7 @@ namespace LuaGlobalFunctions
      *    end
      * end)
      * </pre>
-     * 
+     *
      * @param string sql : query to execute asynchronously
      * @param function callback : the callback function to be called with the query results
      */
@@ -1414,7 +1414,7 @@ namespace LuaGlobalFunctions
         // Add an asynchronous query callback
         E->GetQueryProcessor().AddCallback(WorldDatabase.AsyncQuery(query).WithCallback([E, funcRef](QueryResult result)
         {
-            ElunaQuery* eq = result ? new ElunaQuery(result) : nullptr;
+            ElunaQuery* eq = result ? &result : nullptr;
 
             // Get the Lua function from the registry
             lua_rawgeti(E->L, LUA_REGISTRYINDEX, funcRef);
@@ -1446,9 +1446,9 @@ namespace LuaGlobalFunctions
     {
         const char* query = E->CHECKVAL<const char*>(1);
 
-        QueryResult result = CharacterDatabase.Query(query);
+        ElunaQuery result = CharacterDatabase.Query(query);
         if (result)
-            E->Push(new QueryResult(result));
+            E->Push(&result);
         else
             E->Push();
 
@@ -1505,7 +1505,7 @@ namespace LuaGlobalFunctions
         // Add an asynchronous query callback
         E->GetQueryProcessor().AddCallback(CharacterDatabase.AsyncQuery(query).WithCallback([E, funcRef](QueryResult result)
         {
-            ElunaQuery* eq = result ? new ElunaQuery(result) : nullptr;
+            ElunaQuery* eq = result ? &result : nullptr;
 
             // Get the Lua function from the registry
             lua_rawgeti(E->L, LUA_REGISTRYINDEX, funcRef);
@@ -1537,9 +1537,9 @@ namespace LuaGlobalFunctions
     {
         const char* query = E->CHECKVAL<const char*>(1);
 
-        QueryResult result = LoginDatabase.Query(query);
+        ElunaQuery result = LoginDatabase.Query(query);
         if (result)
-            E->Push(new QueryResult(result));
+            E->Push(&result);
         else
             E->Push();
 
@@ -1596,7 +1596,7 @@ namespace LuaGlobalFunctions
         // Add an asynchronous query callback
         E->GetQueryProcessor().AddCallback(LoginDatabase.AsyncQuery(query).WithCallback([E, funcRef](QueryResult result)
         {
-            ElunaQuery* eq = result ? new ElunaQuery(result) : nullptr;
+            ElunaQuery* eq = result ? &result : nullptr;
 
             // Get the Lua function from the registry
             lua_rawgeti(E->L, LUA_REGISTRYINDEX, funcRef);
@@ -2251,7 +2251,7 @@ namespace LuaGlobalFunctions
 
     /**
      * Adds a taxi path to a specified map, returns the used pathId.
-     * 
+     *
      * Note that the first taxi point needs to be near the player when he starts the taxi path.
      * The function should also be used only **once** per path added so use it on server startup for example.
      *
@@ -3170,7 +3170,7 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
-    
+
     ElunaGlobal::ElunaRegister GlobalMethods[] =
     {
         // Hooks

--- a/TrinityCore/PlayerMethods.h
+++ b/TrinityCore/PlayerMethods.h
@@ -3393,9 +3393,9 @@ namespace LuaPlayer
     /**
      * Adds a new item to the gossip menu shown to the [Player] on next call to [Player:GossipSendMenu].
      *
-     * sender and intid are numbers which are passed directly to the gossip selection handler. Internally they are partly used for the database gossip handling.
-     * code specifies whether to show a box to insert text to. The player inserted text is passed to the gossip selection handler.
-     * money specifies an amount of money the player needs to have to click the option. An error message is shown if the player doesn't have enough money.
+     * sender and intid are numbers which are passed directly to the gossip selection handler. Internally they are partly used for the database gossip handling.<br />
+     * code specifies whether to show a box to insert text to. The player inserted text is passed to the gossip selection handler.<br />
+     * money specifies an amount of money the player needs to have to click the option. An error message is shown if the player doesn't have enough money.<br />
      * Note that the money amount is only checked client side and is not removed from the player either. You will need to check again in your code before taking action.
      *
      * See also: [Player:GossipSendMenu], [Player:GossipAddQuests], [Player:GossipComplete], [Player:GossipClearMenu]

--- a/TrinityCore/PlayerMethods.h
+++ b/TrinityCore/PlayerMethods.h
@@ -143,7 +143,7 @@ namespace LuaPlayer
             E->Push(player->HasTitle(titleInfo));
         return 1;
     }
-    
+
     /**
      * Returns 'true' if the [Player] has the given amount of item entry specified, 'false' otherwise.
      *
@@ -160,7 +160,7 @@ namespace LuaPlayer
         E->Push(player->HasItemCount(itemId, count, check_bank));
         return 1;
     }
-    
+
     /**
      * Returns 'true' if the [Player] has a quest for the item entry specified, 'false' otherwise.
      *
@@ -174,7 +174,7 @@ namespace LuaPlayer
         E->Push(player->HasQuestForItem(entry));
         return 1;
     }
-    
+
     /**
      * Returns 'true' if the [Player] can use the item or item entry specified, 'false' otherwise.
      *
@@ -349,7 +349,7 @@ namespace LuaPlayer
             E->Push(false);
         return 1;
     }
-    
+
     /**
      * Returns 'true' if the [Player] is immune to everything.
      *
@@ -1318,7 +1318,7 @@ namespace LuaPlayer
         E->Push(player->GetItemByEntry(entry));
         return 1;
     }
-    
+
     /**
      * Returns the database textID of the [WorldObject]'s gossip header text for the [Player]
      *
@@ -1386,7 +1386,7 @@ namespace LuaPlayer
         E->Push(player->GetTeamId());
         return 1;
     }
-    
+
     /**
      * Returns amount of the specified [Item] the [Player] has.
      *
@@ -2022,7 +2022,7 @@ namespace LuaPlayer
         player->ResetAchievements();
         return 0;
     }
-    
+
     /**
      * Shows the mailbox window to the player from specified guid.
      *
@@ -2196,7 +2196,7 @@ namespace LuaPlayer
         player->GetSession()->SendShowBank(obj->GET_GUID());
         return 0;
     }
-    
+
     /**
      * Sends a vendor window to the [Player] from the [WorldObject] specified.
      *
@@ -2953,7 +2953,7 @@ namespace LuaPlayer
         player->AutoUnequipOffhandIfNeed();
         return 1;
     }
-    
+
     /**
      * Returns true if the player can equip the given [Item] or item entry to the given slot, false otherwise.
      *
@@ -3112,7 +3112,7 @@ namespace LuaPlayer
         player->SetUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, currentKills + val);
         return 0;
     }
-    
+
     /**
      * Adds the given amount of the specified item entry to the player.
      *
@@ -3142,7 +3142,7 @@ namespace LuaPlayer
         E->Push(item);
         return 1;
     }
-    
+
     /**
      * Removes the given amount of the specified [Item] from the player.
      *
@@ -3393,9 +3393,9 @@ namespace LuaPlayer
     /**
      * Adds a new item to the gossip menu shown to the [Player] on next call to [Player:GossipSendMenu].
      *
-     * sender and intid are numbers which are passed directly to the gossip selection handler. Internally they are partly used for the database gossip handling.  
-     * code specifies whether to show a box to insert text to. The player inserted text is passed to the gossip selection handler.  
-     * money specifies an amount of money the player needs to have to click the option. An error message is shown if the player doesn't have enough money.  
+     * sender and intid are numbers which are passed directly to the gossip selection handler. Internally they are partly used for the database gossip handling.
+     * code specifies whether to show a box to insert text to. The player inserted text is passed to the gossip selection handler.
+     * money specifies an amount of money the player needs to have to click the option. An error message is shown if the player doesn't have enough money.
      * Note that the money amount is only checked client side and is not removed from the player either. You will need to check again in your code before taking action.
      *
      * See also: [Player:GossipSendMenu], [Player:GossipAddQuests], [Player:GossipComplete], [Player:GossipClearMenu]
@@ -3465,7 +3465,7 @@ namespace LuaPlayer
      * Clears the [Player]s current gossip item list.
      *
      * See also: [Player:GossipMenuAddItem], [Player:GossipSendMenu], [Player:GossipAddQuests], [Player:GossipComplete]
-     * 
+     *
      *     Note: This is needed when you show a gossip menu without using gossip hello or select hooks which do this automatically.
      *     Usually this is needed when using [Player] is the sender of a Gossip Menu.
      */
@@ -3798,7 +3798,7 @@ namespace LuaPlayer
         player->RemovePet(player->GetPet(), (PetSaveMode)mode, returnreagent);
         return 0;
     }
-    
+
     ElunaRegister<Player> PlayerMethods[] =
     {
         // Getters

--- a/VMangos/ElunaQueryMethods.h
+++ b/VMangos/ElunaQueryMethods.h
@@ -7,11 +7,7 @@
 #ifndef QUERYMETHODS_H
 #define QUERYMETHODS_H
 
-#if defined TRINITY || defined AZEROTHCORE
 #define RESULT  (*result)
-#else
-#define RESULT  result
-#endif
 
 /***
  * The result of a database query.

--- a/VMangos/GlobalMethods.h
+++ b/VMangos/GlobalMethods.h
@@ -327,10 +327,10 @@ namespace LuaGlobalFunctions
      * Low GUID is an ID to distinct the objects of the same type.
      *
      * [Player] and [Creature] for example can have the same low GUID but not GUID.
-     * 
+     *
      * On TrinityCore all low GUIDs are different for all objects of the same type.
      * For example creatures in instances are assigned new GUIDs when the Map is created.
-     * 
+     *
      * On MaNGOS and cMaNGOS low GUIDs are unique only on the same map.
      * For example creatures in instances use the same low GUID assigned for that spawn in the database.
      * This is why to identify a creature you have to know the instanceId and low GUID. See [Map:GetIntstanceId]
@@ -1227,9 +1227,12 @@ namespace LuaGlobalFunctions
     {
         const char* query = E->CHECKVAL<const char*>(1);
 
-        ElunaQuery* result = WorldDatabase.QueryNamed(query);
+        QueryNamedResult* result = WorldDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -1272,7 +1275,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = CharacterDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -1315,7 +1321,10 @@ namespace LuaGlobalFunctions
 
         QueryNamedResult* result = LoginDatabase.QueryNamed(query);
         if (result)
-            E->Push(result);
+        {
+            ElunaQuery elunaQuery(result);
+            E->Push(&elunaQuery);
+        }
         else
             E->Push();
         return 1;
@@ -1960,7 +1969,7 @@ namespace LuaGlobalFunctions
 
     /**
      * Adds a taxi path to a specified map, returns the used pathId.
-     * 
+     *
      * Note that the first taxi point needs to be near the player when he starts the taxi path.
      * The function should also be used only **once** per path added so use it on server startup for example.
      *
@@ -2865,7 +2874,7 @@ namespace LuaGlobalFunctions
 
         return 0;
     }
-    
+
     ElunaGlobal::ElunaRegister GlobalMethods[] =
     {
         // Hooks


### PR DESCRIPTION
Extracted from my other pull request

Simple test showing that query results are still freed properly (/lol then .reload eluna to force gc)
```lua
local function OnTextEmote(event, player, textEmote, emoteNum, guid)
    for k, v in pairs(CharDBQuery("SELECT 1 as dummy"):GetRow()) do
	    player:SendBroadcastMessage(k.." = "..v)
	end
end

RegisterPlayerEvent(24, OnTextEmote)
```

![obraz](https://github.com/ElunaLuaEngine/Eluna/assets/297439/aeba9ee4-73f7-449f-9079-770b65b2d038)
