### PR TITLE
Move Eluna configuration to its own config file

### DIFF
--- a/ElunaConfig.cpp
+++ b/ElunaConfig.cpp
@@ -30,9 +30,21 @@ void ElunaConfig::Initialize()
     // Load eluna.conf configuration file
 #ifdef TRINITY
     std::string configError;
-    if (!sConfigMgr->LoadAdditionalFile(ELUNA_CONFIG, true, configError))
+    if (!sConfigMgr->LoadInitial(ELUNA_CONFIG, std::vector<std::string>(), configError))
     {
         printf("Error: %s. Eluna will be disabled.\n", configError.c_str());
+        return;
+    }
+#elif CMANGOS
+    if (!config.SetSource(ELUNA_CONFIG, "Mangosd_"))
+    {
+        sLog.outString("Unable to open configuration file(%s). Eluna will be disabled.", ELUNA_CONFIG);
+        return;
+    }
+#elif VMANGOS
+    if (!config.SetSource(ELUNA_CONFIG))
+    {
+        sLog.Out(LOG_BASIC, LOG_LVL_ERROR, "Unable to open configuration file(%s). Eluna will be disabled.", ELUNA_CONFIG);
         return;
     }
 #endif
@@ -53,7 +65,9 @@ void ElunaConfig::SetConfig(ElunaConfigBoolValues index, char const* fieldname, 
 {
 #ifdef TRINITY
     SetConfig(index, sConfigMgr->GetBoolDefault(fieldname, defvalue));
-#elif defined CMANGOS || defined VMANGOS || defined MANGOS
+#elif defined CMANGOS || defined VMANGOS
+    SetConfig(index, config.GetBoolDefault(fieldname, defvalue));
+#elif MANGOS
     SetConfig(index, sConfig.GetBoolDefault(fieldname, defvalue));
 #endif
 }
@@ -63,8 +77,10 @@ void ElunaConfig::SetConfig(ElunaConfigStringValues index, char const* fieldname
 #ifdef TRINITY
     SetConfig(index, sConfigMgr->GetStringDefault(fieldname, defvalue));
 #elif CMANGOS
-    SetConfig(index, sConfig.GetStringDefault(fieldname, defvalue));
-#elif defined VMANGOS || defined MANGOS
+    SetConfig(index, config.GetStringDefault(fieldname, defvalue));
+#elif VMANGOS
+    SetConfig(index, config.GetStringDefault(fieldname, defvalue.c_str()));
+#elif MANGOS
     SetConfig(index, sConfig.GetStringDefault(fieldname, defvalue.c_str()));
 #endif
 }

--- a/ElunaConfig.cpp
+++ b/ElunaConfig.cpp
@@ -27,8 +27,18 @@ ElunaConfig::~ElunaConfig()
 
 void ElunaConfig::Initialize()
 {
+    // Load eluna.conf configuration file
+#ifdef TRINITY
+    std::string configError;
+    if (!sConfigMgr->LoadAdditionalFile(ELUNA_CONFIG, true, configError))
+    {
+        printf("Error: %s. Eluna will be disabled.\n", configError.c_str());
+        return;
+    }
+#endif
+
     // Load bools
-    SetConfig(CONFIG_ELUNA_ENABLED, "Eluna.Enabled", true);
+    SetConfig(CONFIG_ELUNA_ENABLED, "Eluna.Enabled", false);
     SetConfig(CONFIG_ELUNA_COMPATIBILITY_MODE, "Eluna.CompatibilityMode", true);
     SetConfig(CONFIG_ELUNA_TRACEBACK, "Eluna.TraceBack", false);
 

--- a/ElunaConfig.cpp
+++ b/ElunaConfig.cpp
@@ -6,8 +6,6 @@
 
 #if defined TRINITY || defined MANGOS
 #include "Config.h"
-#elif defined CMANGOS || defined VMANGOS
-#include "Config/Config.h"
 #endif
 #include "ElunaConfig.h"
 
@@ -36,7 +34,7 @@ void ElunaConfig::Initialize()
         return;
     }
 #elif CMANGOS
-    if (!config.SetSource(ELUNA_CONFIG, "Mangosd_"))
+    if (!config.SetSource(ELUNA_CONFIG, "Eluna_"))
     {
         sLog.outString("Unable to open configuration file(%s). Eluna will be disabled.", ELUNA_CONFIG);
         return;

--- a/ElunaConfig.h
+++ b/ElunaConfig.h
@@ -8,6 +8,9 @@
 #define _ELUNACONFIG_H
 
 #include "ElunaUtility.h"
+#if defined CMANGOS || defined VMANGOS
+#include "Config/Config.h"
+#endif
 
 #define ELUNA_CONFIG "eluna.conf"
 

--- a/ElunaConfig.h
+++ b/ElunaConfig.h
@@ -55,6 +55,10 @@ private:
 
     void SetConfig(ElunaConfigBoolValues index, char const* fieldname, bool defvalue);
     void SetConfig(ElunaConfigStringValues index, char const* fieldname, std::string defvalue);
+
+#if defined CMANGOS || defined VMANGOS
+    Config config;
+#endif
 };
 
 #define sElunaConfig ElunaConfig::instance()

--- a/ElunaConfig.h
+++ b/ElunaConfig.h
@@ -9,6 +9,8 @@
 
 #include "ElunaUtility.h"
 
+#define ELUNA_CONFIG "eluna.conf"
+
 enum ElunaConfigBoolValues
 {
     CONFIG_ELUNA_ENABLED,

--- a/eluna.conf.dist
+++ b/eluna.conf.dist
@@ -1,0 +1,61 @@
+################################################
+# Eluna configuration file                     #
+################################################
+[eluna]
+
+###################################################################################################
+#  ELUNA SETTINGS
+#
+#   Eluna.Enabled
+#       Description: Enable or disable Eluna LuaEngine
+#       Default:     true  - (enabled)
+#                    false - (disabled)
+#
+#   Eluna.CompatibilityMode
+#       Description: Toggles Eluna between compatibility mode (single-threaded) or multistate mode. 
+#                    Compatibility mode limits the core to a single map update thread.
+#       Default:     true  - (enabled)
+#                    false - (disabled)
+#
+#   Eluna.OnlyOnMaps
+#       Description: When Eluna is enabled, a state will only be created for a list of specified maps
+#                    This only works for multistate mode.
+#       Default:     ""  - (enabled on all maps)
+#                    "0,1,2,..." - (enabled on specific maps only)
+#
+#   Eluna.TraceBack
+#       Description: Sets whether to use debug.traceback function on a lua error or not.
+#                    Notice that you can redefine the function.
+#       Default:     false - (use default error output)
+#                    true  - (use debug.traceback function)
+#
+#   Eluna.ScriptPath
+#       Description: Sets the location of the script folder to load scripts from
+#                    The path can be relative or absolute.
+#       Default:     "lua_scripts"
+#
+#   Eluna.RequirePaths
+#       Description: Sets the location of additional require paths.
+#                    These paths are absolute and follows the standard Lua require path patterns.
+#                    Below are a set of "standard" paths used by most package managers.
+#                    "/usr/share/%s/?.lua;/usr/local/share/lua/%s/?.lua;/usr/local/share/lua/%s/?/init.lua;/usr/share/lua/%s/?.lua;/usr/share/lua/%s/?/init.lua;"
+#       Default:     ""
+#
+#   Eluna.RequireCPaths
+#       Description: Sets the location of additional require C paths.
+#                    These paths are absolute and follows the standard Lua require path patterns.
+#                    Below are a set of "standard" paths used by most package managers.
+#                    "/usr/local/lib/lua/%s/?.so;/usr/lib/x86_64-linux-gnu/lua/%s/?.so;/usr/local/lib/lua/%s/loadall.so;"
+#       Default:     ""
+#
+
+Eluna.Enabled = true
+Eluna.CompatibilityMode = true
+Eluna.OnlyOnMaps = ""
+Eluna.TraceBack = false
+Eluna.ScriptPath = "lua_scripts"
+Eluna.RequirePaths = ""
+Eluna.RequireCPaths = ""
+
+#
+###################################################################################################

--- a/methods/VMangos/CreatureMethods.h
+++ b/methods/VMangos/CreatureMethods.h
@@ -1102,7 +1102,7 @@ namespace LuaCreature
     {
         uint32 entry = creature->GetEntry();
 
-        CreatureInfo const* cInfo = ObjectMgr::GetCreatureTemplate(entry);
+        CreatureInfo const* cInfo = sObjectMgr.GetCreatureTemplate(entry);
         if (cInfo)
             E->Push(cInfo->pet_family);
         return 1;

--- a/methods/VMangos/GlobalMethods.h
+++ b/methods/VMangos/GlobalMethods.h
@@ -1475,7 +1475,7 @@ namespace LuaGlobalFunctions
         {
             if (save)
             {
-                CreatureInfo const* cinfo = ObjectMgr::GetCreatureTemplate(entry);
+                CreatureInfo const* cinfo = sObjectMgr.GetCreatureTemplate(entry);
                 if (!cinfo)
                 {
                     E->Push();
@@ -1516,7 +1516,7 @@ namespace LuaGlobalFunctions
             }
             else
             {
-                CreatureInfo const* cinfo = ObjectMgr::GetCreatureTemplate(entry);
+                CreatureInfo const* cinfo = sObjectMgr.GetCreatureTemplate(entry);
                 if (!cinfo)
                 {
                     E->Push();

--- a/methods/VMangos/PlayerMethods.h
+++ b/methods/VMangos/PlayerMethods.h
@@ -2841,7 +2841,7 @@ namespace LuaPlayer
             }
             else if (creature > 0)
             {
-                if (CreatureInfo const* cInfo = ObjectMgr::GetCreatureTemplate(creature))
+                if (CreatureInfo const* cInfo = sObjectMgr.GetCreatureTemplate(creature))
                     for (uint16 z = 0; z < creaturecount; ++z)
 #ifndef CMANGOS
                         player->KilledMonster(cInfo, ObjectGuid());


### PR DESCRIPTION
Now that we're using out own configuration manager, it only makes sense to move config related settings away from the worldserver config file. Thoughts?