### PR TITLE
Optimize stacktrace functionality

### DIFF
--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -187,6 +187,10 @@ private:
     // Whether or not Eluna is in compatibility mode. Used in some method wrappers.
     bool compatibilityMode;
 
+    // Index of the Eluna::StackTrace function pushed to the lua state stack when lua is opened
+    // We store the function to stack on lua open because it cannot be a pseudo-index (must be on stack) and we want access it on every call
+    int stacktraceFunctionStackIndex = 0;
+
     // Map from instance ID -> Lua table ref
     std::unordered_map<uint32, int> instanceDataRefs;
     // Map from map ID -> Lua table ref


### PR DESCRIPTION
We now push the function to stack only once and never shift all function call arguments around.