### PR TITLE
Fix nullptr crash in ElunaEventProcessor

### DIFF
--- a/ElunaEventMgr.cpp
+++ b/ElunaEventMgr.cpp
@@ -26,12 +26,10 @@ ElunaEventProcessor::ElunaEventProcessor(Eluna* _E, WorldObject* _obj) : m_time(
 
 ElunaEventProcessor::~ElunaEventProcessor()
 {
-    {
+    if (E && E->eventMgr) {
         RemoveEvents_internal();
-    }
-
-    if (obj)
         E->eventMgr->processors.erase(this);
+    }
 }
 
 void ElunaEventProcessor::Update(uint32 diff)


### PR DESCRIPTION
Fixes:

Exception thrown: read access violation.
this->E->eventMgr was nullptr.

in code:

```
ElunaEventProcessor::~ElunaEventProcessor()
{
    {
        RemoveEvents_internal();
    }

    if (obj)
        E->eventMgr->processors.erase(this);
}

```
