### PR TITLE
Improve compatibility with TrinityCore master branch

### DIFF
--- a/BindingMap.h
+++ b/BindingMap.h
@@ -355,7 +355,7 @@ namespace std
 
         hash_helper::result_type operator()(argument_type const& k) const
         {
-            return hash_helper::hash(k.event_id, k.instance_id, k.guid.GetRawValue());
+            return hash_helper::hash(k.event_id, k.instance_id, k.guid);
         }
     };
 }

--- a/LuaEngine.cpp
+++ b/LuaEngine.cpp
@@ -958,7 +958,13 @@ int Eluna::Register(uint8 regtype, uint32 entry, ObjectGuid guid, uint32 instanc
     }
     luaL_unref(L, LUA_REGISTRYINDEX, functionRef);
     std::ostringstream oss;
-    oss << "regtype " << static_cast<uint32>(regtype) << ", event " << event_id << ", entry " << entry << ", guid " << guid.GetRawValue() << ", instance " << instanceId;
+    oss << "regtype " << static_cast<uint32>(regtype) << ", event " << event_id << ", entry " << entry << ", guid " <<
+#ifdef TRINITY
+        guid.ToHexString()
+#else
+        guid.GetRawValue()
+#endif
+        << ", instance " << instanceId;
     luaL_error(L, "Unknown event type (%s)", oss.str().c_str());
     return 0;
 }


### PR DESCRIPTION
Allows using less #ifdefs when trying to support master branch

Additional changes for ElunaQuery:GetRow() 
* add missing unsigned and floating point types support (since TrinityCore/TrinityCore@24fc0dcb1ee627cdec5ff5670a85050afc62d281)
* switched it to use new GetFieldMetadata, making patching Field and QueryResult in ElunaLuaEngine/ElunaTrinityWotlk unneccessary

Requires latest changes in 3.3.5 branch to compile