### PR TITLE
Eluna lanes communication

### DIFF
--- a/ElunaStateCommunication.cpp
+++ b/ElunaStateCommunication.cpp
@@ -1,0 +1,45 @@
+#include "ElunaStateCommunication.h"
+#include <iostream>
+
+std::unordered_map<int, std::unordered_map<std::string, std::function<void(std::string)>>> ElunaStateCommunication::events;
+
+void ElunaStateCommunication::Register(lua_State* L)
+{
+    lua_register(L, "RegisterStateEvent", ElunaStateCommunication::RegisterStateEvent);
+    lua_register(L, "NotifyStateEvent", ElunaStateCommunication::NotifyStateEvent);
+}
+
+int ElunaStateCommunication::RegisterStateEvent(lua_State* L)
+{
+    int mapId = luaL_checkint(L, 1);
+    const char* eventName = luaL_checkstring(L, 2);
+    
+    if (!lua_isfunction(L, 3)) {
+        luaL_error(L, "Expected a function as the third argument");
+        return 0;
+    }
+
+    lua_pushvalue(L, 3);
+    int callbackRef = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    events[mapId][eventName] = [L, callbackRef](std::string data) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, callbackRef);
+        lua_pushstring(L, data.c_str());
+        lua_call(L, 1, 0);
+    };
+
+    return 0;
+}
+
+int ElunaStateCommunication::NotifyStateEvent(lua_State* L)
+{
+    int mapId = luaL_checkint(L, 1);
+    const char* eventName = luaL_checkstring(L, 2);
+    const char* data = luaL_checkstring(L, 3);
+
+    if (events.find(mapId) != events.end() && events[mapId].find(eventName) != events[mapId].end()) {
+        events[mapId][eventName](data);
+    }
+
+    return 0;
+}

--- a/ElunaStateCommunication.h
+++ b/ElunaStateCommunication.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <unordered_map>
+#include <string>
+#include <functional>
+#include "lua.hpp"
+
+class ElunaStateCommunication
+{
+public:
+    static void Register(lua_State* L);
+
+    static int RegisterStateEvent(lua_State* L);
+    static int NotifyStateEvent(lua_State* L);
+
+private:
+    static std::unordered_map<int, std::unordered_map<std::string, std::function<void(std::string)>>> events; // Evénements par mapId
+};

--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "CorpseMethods.h"
 #include "VehicleMethods.h"
 #include "BattleGroundMethods.h"
+#include "ElunaStateCommunication.h"
 
 #if defined TRACKABLE_PTR_NAMESPACE
 ElunaConstrainedObjectRef<Aura> GetWeakPtrFor(Aura const* obj)
@@ -224,4 +225,5 @@ void RegisterFunctions(Eluna* E)
     ElunaTemplate<ObjectGuid>::Register(E, "ObjectGuid");
 
     LuaVal::Register(E->L);
+    ElunaStateCommunication::Register(E->L);
 }


### PR DESCRIPTION
This system introduces a Mediator pattern to Eluna, allowing communication between different Lua states based on "mapId". It enables the registration and notification of events across states, such as player logins or custom actions.

### How It Works:
- Each Lua state is identified by its mapId, and a "main" state (mapId == -1).
- Events can be registered in one state and triggered from another, allowing cross-state communication.
- Currently, only the string type can be passed between states.

### Little Example
```lua
local mapId = GetStateMapId()

if mapId == -1 then
    -- Main state (controller)
    local function OnGiveExperience(playerName)
        print(playerName .. " has connected from another state!")
    end
    RegisterStateEvent(mapId, "OnGiveExperience", OnGiveExperience)
else
    -- Specific state (mapId)
    local function OnGiveExperience(event, player)
        NotifyStateEvent(-1, "OnGiveExperience", tostring(player:GetName()))
    end
    RegisterPlayerEvent(12, OnGiveExperience)
end
```

This system can be expanded in the future to support additional data types and more complex interactions between Lua states.