### PR TITLE
Revert "Optimize stacktrace functionality (#477)"

### DIFF
--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -174,10 +174,6 @@ private:
     // Whether or not Eluna is in compatibility mode. Used in some method wrappers.
     bool compatibilityMode;
 
-    // Index of the Eluna::StackTrace function pushed to the lua state stack when lua is opened
-    // We store the function to stack on lua open because it cannot be a pseudo-index (must be on stack) and we want access it on every call
-    int stacktraceFunctionStackIndex = 0;
-
     // Map from instance ID -> Lua table ref
     std::unordered_map<uint32, int> instanceDataRefs;
     // Map from map ID -> Lua table ref


### PR DESCRIPTION
This reverts commit 24cae109a5b5bcbbd59e3c09e553322a85793626.

Fixes crash with hook calls nested within method calls when Eluna.TraceBack is true.
If you have this issue currently, then set Eluna.TraceBack to false in Eluna server config or update your core so it has this fix in.