### PR TITLE
Implemented AddItemAppearance and AddTransmogSet

### DIFF
--- a/methods/TrinityCore/PlayerMethods.h
+++ b/methods/TrinityCore/PlayerMethods.h
@@ -4037,6 +4037,34 @@ namespace LuaPlayer
         return 0;
     }
 
+    /**
+     * Add item appearance to the [Player].
+     *
+     * @param uint32 itemId : the ID of the item to add appearance from
+     */
+    int AddItemAppearance(Eluna* E, Player* player)
+    {
+        uint32 entry = E->CHECKVAL<uint32>(2);
+
+        player->GetSession()->GetCollectionMgr()->AddItemAppearance(entry);
+
+        return 0;
+    }
+
+    /**
+     * Add transmog set appearances to the [Player].
+     *
+     * @param uint32 transmogSetId : the ID of the set to add all appearances from
+     */
+    int AddTransmogSet(Eluna* E, Player* player)
+    {
+        uint32 entry = E->CHECKVAL<uint32>(2);
+
+        player->GetSession()->GetCollectionMgr()->AddTransmogSet(entry);
+
+        return 0;
+    }
+
     ElunaRegister<Player> PlayerMethods[] =
     {
         // Getters
@@ -4244,6 +4272,8 @@ namespace LuaPlayer
         { "CanRewardQuest", &LuaPlayer::CanRewardQuest },
         { "HasRecruited", &LuaPlayer::HasRecruited },
         { "IsRecruited", &LuaPlayer::IsRecruited },
+        { "AddItemAppearance", &LuaPlayer::AddItemAppearance },
+        { "AddTransmogSet", &LuaPlayer::AddTransmogSet },
 
         // Gossip
 #if ELUNA_EXPANSION < EXP_RETAIL


### PR DESCRIPTION
# Implements
- Player: AddItemAppearance(itemId) to add item's appearance to the [Player]
- Player: AddTransmogSet(transmogSetId) to add all item's of transmog set appearances to the [Player]

## Build ✅ 
## Test ingame ✅ 

# Usage:
```lua
player:AddItemAppearance(123)
player:AddTransmogSet(123)
```