### PR TITLE
Implement ElunaMgr

### DIFF
--- a/ElunaMgr.cpp
+++ b/ElunaMgr.cpp
@@ -55,11 +55,6 @@ void ElunaMgr::Destroy(ElunaInfo const& info)
     Destroy(info.key);
 }
 
-ElunaInfo::ElunaInfo(uint32 mapId, uint32 instanceId)
-{
-    key = ElunaInfoKey::MakeKey(mapId, instanceId);
-}
-
 ElunaInfo::~ElunaInfo()
 {
     if (IsValid() && sElunaMgr)

--- a/ElunaMgr.h
+++ b/ElunaMgr.h
@@ -65,7 +65,6 @@ struct ElunaInfo
 public:
     ElunaInfo() : key() {}
     ElunaInfo(ElunaInfoKey key) : key(key) {}
-    ElunaInfo(uint32 mapId, uint32 instanceId);
     ~ElunaInfo();
 
 public:


### PR DESCRIPTION
Decouples Eluna object ownership from the map/world objects. Allows for maps/world having multiple Lua states each in the future, if necessary.