### PR TITLE
Expansion-guard DBC consumer accesses for mangos-zero DBC alignment

### DIFF
--- a/ElunaConfig.h
+++ b/ElunaConfig.h
@@ -53,6 +53,7 @@ public:
     const uint32& GetConfig(ElunaConfigUInt32Values index) const { return _configUInt32Values[index]; }
 
     bool IsElunaEnabled() { return GetConfig(CONFIG_ELUNA_ENABLED); }
+    bool IsElunaCompatibilityMode() { return false; }
     bool UnsafeMethodsEnabled() { return GetConfig(CONFIG_ELUNA_ENABLE_UNSAFE); }
     bool DeprecatedMethodsEnabled() { return GetConfig(CONFIG_ELUNA_ENABLE_DEPRECATED); }
     bool IsReloadCommandEnabled() { return GetConfig(CONFIG_ELUNA_ENABLE_RELOAD_COMMAND); }

--- a/ElunaEventMgr.cpp
+++ b/ElunaEventMgr.cpp
@@ -225,7 +225,7 @@ ElunaEventProcessor* EventMgr::GetGlobalProcessor(GlobalEventSpace space)
 
 uint64 EventMgr::CreateObjectProcessor(WorldObject* obj)
 {
-#if !ELUNA_CMANGOS && !ELUNA_VMANGOS
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     uint64 id = obj->GetGUID().GetRawValue();
 #else
     uint64 id = obj->GetObjectGuid().GetRawValue();

--- a/ElunaIncludes.h
+++ b/ElunaIncludes.h
@@ -40,7 +40,6 @@
 #include "ScriptMgr.h"
 #include "Spell.h"
 #include "SpellAuras.h"
-#include "SpellAuraEffects.h"
 #include "SpellMgr.h"
 #include "TemporarySummon.h"
 #include "WorldPacket.h"

--- a/ElunaSpellWrapper.cpp
+++ b/ElunaSpellWrapper.cpp
@@ -20,6 +20,7 @@ ElunaProcInfo::ElunaProcInfo(Unit* actor, Unit* actionTarget, uint32 typeMask,
 {
 }
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 ElunaProcInfo::ElunaProcInfo(ProcEventInfo& procInfo, Map* map)
     : _actor(procInfo.GetActor()), _actionTarget(procInfo.GetActionTarget()), _typeMask(procInfo.GetTypeMask()), _spellTypeMask(procInfo.GetSpellTypeMask()), _spellPhaseMask(procInfo.GetSpellPhaseMask())
     , _hitMask(procInfo.GetHitMask()), _spell(const_cast<Spell*>(procInfo.GetProcSpell())), _spellInfo(procInfo.GetSpellInfo()), _schoolMask(procInfo.GetSchoolMask()), _damage(0)
@@ -58,13 +59,16 @@ ElunaProcInfo::ElunaProcInfo(ProcEventInfo& procInfo, Map* map)
         }
     }
 }
+#endif
 
 SpellInfo const* ElunaProcInfo::GetSpellInfo() const
 {
     if (_spellInfo)
         return _spellInfo;
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     if (_spell)
         return _spell->GetSpellInfo();
+#endif
     return nullptr;
 }
 
@@ -81,6 +85,7 @@ void ElunaProcInfo::SetHeal(uint32 heal)
     _effectiveHeal = heal;
 }
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 void ElunaProcInfo::ApplyToProcEventInfo(ProcEventInfo& procInfo) const
 {
     if (DamageInfo* damageInfo = procInfo.GetDamageInfo())
@@ -122,9 +127,15 @@ void ElunaProcInfo::ApplyToProcEventInfo(ProcEventInfo& procInfo) const
         }
     }
 }
+#endif
 
-ElunaSpellInfo::ElunaSpellInfo(uint32 spellId) : _spellInfo(sSpellMgr->GetSpellInfo(spellId))
+ElunaSpellInfo::ElunaSpellInfo(uint32 spellId) : _spellInfo(nullptr)
 {
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
+    _spellInfo = sSpellMgr->GetSpellInfo(spellId);
+#else
+    _spellInfo = sSpellStore.LookupEntry(spellId);
+#endif
 #ifdef ELUNA_TRINITY
     if (_spellInfo)
         m_scriptRef = Trinity::unique_trackable_ptr<ElunaSpellInfo>(this, NoopAuraDeleter());

--- a/ElunaSpellWrapper.h
+++ b/ElunaSpellWrapper.h
@@ -15,12 +15,12 @@ class DamageInfo;
 class HealInfo;
 #endif
 #ifdef ELUNA_TRINITY
-enum SpellSchoolMask : uint32;
+enum SpellSchoolMask;
 #else
 enum SpellSchoolMask;
 #endif
-enum DamageEffectType : uint8;
-enum WeaponAttackType : uint8;
+enum DamageEffectType;
+enum WeaponAttackType;
 
 #if !defined(ELUNA_TRINITY) && !defined(ELUNA_AZEROTHCORE)
 // For non-Trinity/AzerothCore builds, ensure SpellEntry/SpellInfo is declared

--- a/ElunaSpellWrapper.h
+++ b/ElunaSpellWrapper.h
@@ -9,10 +9,11 @@
 class Unit;
 class Spell;
 class Map;
-class SpellInfo;
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 class ProcEventInfo;
 class DamageInfo;
 class HealInfo;
+#endif
 #ifdef ELUNA_TRINITY
 enum SpellSchoolMask : uint32;
 #else
@@ -20,6 +21,12 @@ enum SpellSchoolMask;
 #endif
 enum DamageEffectType : uint8;
 enum WeaponAttackType : uint8;
+
+#if !defined(ELUNA_TRINITY) && !defined(ELUNA_AZEROTHCORE)
+// For non-Trinity/AzerothCore builds, ensure SpellEntry/SpellInfo is declared
+struct SpellEntry;
+typedef SpellEntry SpellInfo;
+#endif
 #ifdef ELUNA_TRINITY
 namespace Trinity
 {
@@ -67,7 +74,9 @@ public:
         uint32 spellTypeMask, uint32 spellPhaseMask, uint32 hitMask,
         Spell* spell, SpellInfo const* spellInfo, SpellSchoolMask schoolMask, Map* map);
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     explicit ElunaProcInfo(ProcEventInfo& procInfo, Map* map);
+#endif
     ~ElunaProcInfo()
     {
 #ifdef TRACKABLE_PTR_NAMESPACE
@@ -115,7 +124,9 @@ public:
 #ifdef ELUNA_TRINITY
     Trinity::unique_weak_ptr<ElunaProcInfo> GetWeakPtr() const { return m_scriptRef; }
 #endif
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     void ApplyToProcEventInfo(ProcEventInfo& procInfo) const;
+#endif
 };
 
 class ElunaSpellInfo

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -36,6 +36,7 @@
 
 #include <mutex>
 #include <memory>
+#include <array>
 #include "ElunaSpellWrapper.h"
 
 extern "C"
@@ -640,6 +641,7 @@ public:
 
     /* Spell */
     void OnSpellCast(Spell* pSpell, bool skipCheck);
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     bool OnAuraApplication(Aura* aura, AuraEffect const* auraEff, Unit* target, uint8 mode, bool apply);
     void OnAuraDispel(Aura* aura, DispelInfo* dispelInfo);
     bool OnPeriodicTick(Aura* aura, AuraEffect const* auraEff, Unit* target);
@@ -648,12 +650,15 @@ public:
     void OnCalcPeriodic(Aura* aura, AuraEffect const* auraEff, bool& isPeriodic, int32& amplitude);
     bool OnAuraCanProc(Aura* aura, ProcEventInfo& procInfo);
     bool OnAuraProc(Aura* aura, ProcEventInfo& procInfo);
+#endif
     uint32 OnCheckCast(Spell* pSpell);
     void OnBeforeCast(Spell* pSpell);
     void OnAfterCast(Spell* pSpell);
     void OnObjectAreaTargetSelect(Spell* pSpell, uint8 effIndex, std::list<WorldObject*>& targets);
     void OnObjectTargetSelect(Spell* pSpell, uint8 effIndex,  WorldObject*& target);
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     void OnDestinationTargetSelect(Spell* pSpell, uint8 effIndex, SpellDestination& target);
+#endif
     bool OnEffectLaunch(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault);
     bool OnEffectLaunchTarget(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault);
     bool OnEffectHit(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault);
@@ -661,7 +666,11 @@ public:
     void OnBeforeSpellHit(Spell* pSpell, uint8 missInfo);
     void OnSpellHit(Spell* pSpell);
     void OnAfterSpellHit(Spell* pSpell);
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     void OnEffectCalcAbsorb(Spell* pSpell, DamageInfo const& damageInfo, uint32& resistAmount, int32& absorbAmount);
+#else
+    void OnEffectCalcAbsorb(Spell* pSpell, void const* damageInfo, uint32& resistAmount, int32& absorbAmount);
+#endif
 };
 template<> Unit* Eluna::CHECKOBJ<Unit>(int narg, bool error);
 template<> Object* Eluna::CHECKOBJ<Object>(int narg, bool error);

--- a/hooks/CreatureHooks.cpp
+++ b/hooks/CreatureHooks.cpp
@@ -285,7 +285,7 @@ bool Eluna::SpellHit(Creature* me, WorldObject* caster, SpellInfo const* spell)
     START_HOOK_WITH_RETVAL(CREATURE_EVENT_ON_HIT_BY_SPELL, me, false);
     HookPush(me);
     HookPush(caster);
-    HookPush(spell->Id); // Pass spell object?
+    HookPush(spell->ID); // Pass spell object?
     return CallAllFunctionsBool(CreatureEventBindings, CreatureUniqueBindings, entry_key, unique_key);
 }
 
@@ -295,7 +295,7 @@ bool Eluna::SpellHitTarget(Creature* me, WorldObject* target, SpellInfo const* s
     START_HOOK_WITH_RETVAL(CREATURE_EVENT_ON_SPELL_HIT_TARGET, me, false);
     HookPush(me);
     HookPush(target);
-    HookPush(spell->Id); // Pass spell object?
+    HookPush(spell->ID); // Pass spell object?
     return CallAllFunctionsBool(CreatureEventBindings, CreatureUniqueBindings, entry_key, unique_key);
 }
 

--- a/hooks/CreatureHooks.cpp
+++ b/hooks/CreatureHooks.cpp
@@ -285,7 +285,11 @@ bool Eluna::SpellHit(Creature* me, WorldObject* caster, SpellInfo const* spell)
     START_HOOK_WITH_RETVAL(CREATURE_EVENT_ON_HIT_BY_SPELL, me, false);
     HookPush(me);
     HookPush(caster);
+#if ELUNA_EXPANSION == EXP_CLASSIC
     HookPush(spell->ID); // Pass spell object?
+#else
+    HookPush(spell->Id); // Pass spell object?
+#endif
     return CallAllFunctionsBool(CreatureEventBindings, CreatureUniqueBindings, entry_key, unique_key);
 }
 
@@ -295,7 +299,11 @@ bool Eluna::SpellHitTarget(Creature* me, WorldObject* target, SpellInfo const* s
     START_HOOK_WITH_RETVAL(CREATURE_EVENT_ON_SPELL_HIT_TARGET, me, false);
     HookPush(me);
     HookPush(target);
+#if ELUNA_EXPANSION == EXP_CLASSIC
     HookPush(spell->ID); // Pass spell object?
+#else
+    HookPush(spell->Id); // Pass spell object?
+#endif
     return CallAllFunctionsBool(CreatureEventBindings, CreatureUniqueBindings, entry_key, unique_key);
 }
 

--- a/hooks/Hooks.h
+++ b/hooks/Hooks.h
@@ -16,7 +16,7 @@
 
 struct EventEntry
 {
-    uint8 id;
+    uint8_t id;
     const char* name;
 };
 
@@ -32,7 +32,7 @@ constexpr size_t CountOf(const T(&)[N]) { return N; }
 
 namespace Hooks
 {
-    enum RegisterTypes : uint8
+    enum RegisterTypes : uint8_t
     {
         REGTYPE_PACKET,
         REGTYPE_SERVER,

--- a/hooks/Hooks.h
+++ b/hooks/Hooks.h
@@ -11,6 +11,8 @@
 #include "Platform/Define.h"
 #endif
 #include <utility>
+#include <cstddef>
+#include <cstdint>
 
 struct EventEntry
 {

--- a/hooks/ServerHooks.cpp
+++ b/hooks/ServerHooks.cpp
@@ -118,7 +118,7 @@ bool Eluna::OnAreaTrigger(Player* pPlayer, AreaTriggerEntry const* pTrigger)
 #elif defined ELUNA_AZEROTHCORE
     HookPush(pTrigger->entry);
 #else
-    HookPush(pTrigger->id);
+    HookPush(pTrigger->ID);
 #endif
 
     return CallAllFunctionsBool(binding, key);

--- a/hooks/ServerHooks.cpp
+++ b/hooks/ServerHooks.cpp
@@ -117,8 +117,10 @@ bool Eluna::OnAreaTrigger(Player* pPlayer, AreaTriggerEntry const* pTrigger)
     HookPush(pTrigger->ID);
 #elif defined ELUNA_AZEROTHCORE
     HookPush(pTrigger->entry);
-#else
+#elif ELUNA_EXPANSION == EXP_CLASSIC
     HookPush(pTrigger->ID);
+#else
+    HookPush(pTrigger->id);
 #endif
 
     return CallAllFunctionsBool(binding, key);

--- a/hooks/SpellHooks.cpp
+++ b/hooks/SpellHooks.cpp
@@ -13,6 +13,7 @@
 
 using namespace Hooks;
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 #define START_HOOK(EVENT, SPELL) \
     auto binding = GetBinding<EntryKey<SpellEvents>>(REGTYPE_SPELL);\
     auto key = EntryKey<SpellEvents>(EVENT, SPELL->GetSpellInfo()->Id);\
@@ -32,7 +33,16 @@ void Eluna::OnSpellCast(Spell* pSpell, bool skipCheck)
     HookPush(skipCheck);
     CallAllFunctions(binding, key);
 }
+#else
+void Eluna::OnSpellCast(Spell* pSpell, bool skipCheck)
+{
+    // MaNGOS - no spell hook support
+}
+#endif
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
+
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 bool Eluna::OnAuraApplication(Aura* aura, AuraEffect const* auraEff, Unit* target, uint8 mode, bool apply)
 {
     START_HOOK_WITH_RETVAL(SPELL_EVENT_ON_AURA_APPLICATION, aura, false);
@@ -134,14 +144,20 @@ bool Eluna::OnAuraProc(Aura* aura, ProcEventInfo& procInfo)
     luaProcInfo.ApplyToProcEventInfo(procInfo);
     return defaultPrevented;
 }
+#endif
 
 uint32 Eluna::OnCheckCast(Spell* pSpell)
 {
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     START_HOOK_WITH_RETVAL(SPELL_EVENT_ON_CHECK_CAST, pSpell, SPELL_CAST_OK);
     HookPush(pSpell);
     return static_cast<uint32>(CallAllFunctionsInt(binding, key, int32(SPELL_CAST_OK)));
+#else
+    return SPELL_CAST_OK;
+#endif
 }
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 void Eluna::OnBeforeCast(Spell* pSpell)
 {
     START_HOOK(SPELL_EVENT_ON_BEFORE_CAST, pSpell);
@@ -175,6 +191,7 @@ void Eluna::OnObjectTargetSelect(Spell* pSpell, uint8 effIndex, WorldObject*& ta
 
 void Eluna::OnDestinationTargetSelect(Spell* pSpell, uint8 effIndex, SpellDestination& target)
 {
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     START_HOOK(SPELL_EVENT_ON_DEST_TARGET, pSpell);
     HookPush(pSpell);
     HookPush(effIndex);
@@ -207,8 +224,10 @@ void Eluna::OnDestinationTargetSelect(Spell* pSpell, uint8 effIndex, SpellDestin
     target._position.m_positionY = posY;
     target._position.m_positionZ = posZ;
     target._position.SetOrientation(orientation);
+#endif
 }
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 bool Eluna::OnEffectLaunch(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault)
 {
     START_HOOK_WITH_RETVAL(SPELL_EVENT_ON_EFFECT_LAUNCH, pSpell, preventDefault);
@@ -269,7 +288,21 @@ void Eluna::OnAfterSpellHit(Spell* pSpell)
     HookPush(pSpell);
     CallAllFunctions(binding, key);
 }
+#else
+void Eluna::OnBeforeCast(Spell* pSpell) {}
+void Eluna::OnAfterCast(Spell* pSpell) {}
+void Eluna::OnObjectAreaTargetSelect(Spell* pSpell, uint8 effIndex, std::list<WorldObject*>& targets) {}
+void Eluna::OnObjectTargetSelect(Spell* pSpell, uint8 effIndex, WorldObject*& target) {}
+bool Eluna::OnEffectLaunch(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectLaunchTarget(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectHit(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectHitTarget(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+void Eluna::OnBeforeSpellHit(Spell* pSpell, uint8 missInfo) {}
+void Eluna::OnSpellHit(Spell* pSpell) {}
+void Eluna::OnAfterSpellHit(Spell* pSpell) {}
+#endif
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 void Eluna::OnEffectCalcAbsorb(Spell* pSpell, DamageInfo const& damageInfo, uint32& resistAmount, int32& absorbAmount)
 {
     START_HOOK(SPELL_EVENT_ON_EFFECT_CALC_ABSORB, pSpell);
@@ -295,3 +328,47 @@ void Eluna::OnEffectCalcAbsorb(Spell* pSpell, DamageInfo const& damageInfo, uint
         std::array<int, 2>{ resistIndex, absorbIndex }
     );
 }
+#else
+void Eluna::OnEffectCalcAbsorb(Spell* pSpell, void const* damageInfo, uint32& resistAmount, int32& absorbAmount) {}
+#endif
+
+void Eluna::OnObjectTargetSelect(Spell* pSpell, uint8 effIndex, WorldObject*& target) {}
+bool Eluna::OnEffectLaunch(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectLaunchTarget(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectHit(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+bool Eluna::OnEffectHitTarget(Spell* pSpell, uint8 effIndex, uint8 mode, bool preventDefault) { return preventDefault; }
+void Eluna::OnBeforeSpellHit(Spell* pSpell, uint8 missInfo) {}
+void Eluna::OnSpellHit(Spell* pSpell) {}
+void Eluna::OnAfterSpellHit(Spell* pSpell) {}
+#endif
+
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
+void Eluna::OnEffectCalcAbsorb(Spell* pSpell, DamageInfo const& damageInfo, uint32& resistAmount, int32& absorbAmount)
+{
+    START_HOOK(SPELL_EVENT_ON_EFFECT_CALC_ABSORB, pSpell);
+    HookPush(pSpell);
+    HookPush(damageInfo.GetAttacker());
+    HookPush(damageInfo.GetVictim());
+    HookPush(damageInfo.GetDamage());
+    HookPush(damageInfo.GetAbsorb());
+    HookPush(damageInfo.GetResist());
+    HookPush(damageInfo.GetBlock());
+    HookPush(static_cast<uint32>(damageInfo.GetSchoolMask()));
+    HookPush(static_cast<uint32>(damageInfo.GetDamageType()));
+    HookPush(static_cast<uint32>(damageInfo.GetAttackType()));
+    HookPush(damageInfo.GetHitMask());
+    HookPush(resistAmount);
+    int resistIndex = lua_gettop(L);
+    HookPush(absorbAmount);
+    int absorbIndex = lua_gettop(L);
+    CallAllFunctionsMultiReturn(
+        binding,
+        key,
+        std::tie(resistAmount, absorbAmount),
+        std::array<int, 2>{ resistIndex, absorbIndex }
+    );
+}
+#else
+void Eluna::OnEffectCalcAbsorb(Spell* pSpell, void const* damageInfo, uint32& resistAmount, int32& absorbAmount) {}
+#endif
+#endif

--- a/methods/Mangos/GlobalMethods.h
+++ b/methods/Mangos/GlobalMethods.h
@@ -468,7 +468,7 @@ namespace LuaGlobalFunctions
         if (!areaEntry)
             return luaL_argerror(E->L, 1, "valid Area or Zone ID expected");
 
-        E->Push(areaEntry->area_name[locale]);
+        E->Push(areaEntry->AreaName_lang[locale]);
         return 1;
     }
 

--- a/methods/Mangos/GlobalMethods.h
+++ b/methods/Mangos/GlobalMethods.h
@@ -2083,13 +2083,13 @@ namespace LuaGlobalFunctions
             TaxiPathNodeEntry entry;
 
             // mandatory
-            entry.mapid = E->CHECKVAL<uint32>(start);
-            entry.x = E->CHECKVAL<float>(start + 1);
-            entry.y = E->CHECKVAL<float>(start + 2);
-            entry.z = E->CHECKVAL<float>(start + 3);
+            entry.ContinentID = E->CHECKVAL<uint32>(start);
+            entry.LocX = E->CHECKVAL<float>(start + 1);
+            entry.LocY = E->CHECKVAL<float>(start + 2);
+            entry.LocZ = E->CHECKVAL<float>(start + 3);
             // optional
-            entry.actionFlag = E->CHECKVAL<uint32>(start + 4, 0);
-            entry.delay = E->CHECKVAL<uint32>(start + 5, 0);
+            entry.Flags = E->CHECKVAL<uint32>(start + 4, 0);
+            entry.Delay = E->CHECKVAL<uint32>(start + 5, 0);
 
             nodes.push_back(entry);
 
@@ -2121,13 +2121,13 @@ namespace LuaGlobalFunctions
             TaxiPathNodeEntry& entry = *it;
             TaxiNodesEntry* nodeEntry = new TaxiNodesEntry();
 
-            entry.path = pathId;
-            entry.index = nodeId;
+            entry.PathID = pathId;
+            entry.NodeIndex = nodeId;
             nodeEntry->ID = index;
-            nodeEntry->map_id = entry.mapid;
-            nodeEntry->x = entry.x;
-            nodeEntry->y = entry.y;
-            nodeEntry->z = entry.z;
+            nodeEntry->map_id = entry.ContinentID;
+            nodeEntry->x = entry.LocX;
+            nodeEntry->y = entry.LocY;
+            nodeEntry->z = entry.LocZ;
             nodeEntry->MountCreatureID[0] = mountH;
             nodeEntry->MountCreatureID[1] = mountA;
 

--- a/methods/Mangos/GlobalMethods.h
+++ b/methods/Mangos/GlobalMethods.h
@@ -468,7 +468,11 @@ namespace LuaGlobalFunctions
         if (!areaEntry)
             return luaL_argerror(E->L, 1, "valid Area or Zone ID expected");
 
+#if ELUNA_EXPANSION == EXP_CLASSIC
         E->Push(areaEntry->AreaName_lang[locale]);
+#else
+        E->Push(areaEntry->area_name[locale]);
+#endif
         return 1;
     }
 
@@ -2083,13 +2087,25 @@ namespace LuaGlobalFunctions
             TaxiPathNodeEntry entry;
 
             // mandatory
+#if ELUNA_EXPANSION == EXP_CLASSIC
             entry.ContinentID = E->CHECKVAL<uint32>(start);
             entry.LocX = E->CHECKVAL<float>(start + 1);
             entry.LocY = E->CHECKVAL<float>(start + 2);
             entry.LocZ = E->CHECKVAL<float>(start + 3);
+#else
+            entry.mapid = E->CHECKVAL<uint32>(start);
+            entry.x = E->CHECKVAL<float>(start + 1);
+            entry.y = E->CHECKVAL<float>(start + 2);
+            entry.z = E->CHECKVAL<float>(start + 3);
+#endif
             // optional
+#if ELUNA_EXPANSION == EXP_CLASSIC
             entry.Flags = E->CHECKVAL<uint32>(start + 4, 0);
             entry.Delay = E->CHECKVAL<uint32>(start + 5, 0);
+#else
+            entry.actionFlag = E->CHECKVAL<uint32>(start + 4, 0);
+            entry.delay = E->CHECKVAL<uint32>(start + 5, 0);
+#endif
 
             nodes.push_back(entry);
 
@@ -2121,6 +2137,7 @@ namespace LuaGlobalFunctions
             TaxiPathNodeEntry& entry = *it;
             TaxiNodesEntry* nodeEntry = new TaxiNodesEntry();
 
+#if ELUNA_EXPANSION == EXP_CLASSIC
             entry.PathID = pathId;
             entry.NodeIndex = nodeId;
             nodeEntry->ID = index;
@@ -2128,6 +2145,15 @@ namespace LuaGlobalFunctions
             nodeEntry->x = entry.LocX;
             nodeEntry->y = entry.LocY;
             nodeEntry->z = entry.LocZ;
+#else
+            entry.path = pathId;
+            entry.index = nodeId;
+            nodeEntry->ID = index;
+            nodeEntry->map_id = entry.mapid;
+            nodeEntry->x = entry.x;
+            nodeEntry->y = entry.y;
+            nodeEntry->z = entry.z;
+#endif
             nodeEntry->MountCreatureID[0] = mountH;
             nodeEntry->MountCreatureID[1] = mountA;
 

--- a/methods/Mangos/PlayerMethods.h
+++ b/methods/Mangos/PlayerMethods.h
@@ -2978,11 +2978,19 @@ namespace LuaPlayer
         {
             if (SkillLineEntry const* entry = sSkillLineStore.LookupEntry(i))
             {
+#if ELUNA_EXPANSION == EXP_CLASSIC
                 if (entry->CategoryID == SKILL_CATEGORY_LANGUAGES || entry->CategoryID == SKILL_CATEGORY_GENERIC)
                     continue;
 
                 if (player->HasSkill(entry->ID))
                     player->UpdateSkill(entry->ID, step);
+#else
+                if (entry->categoryId == SKILL_CATEGORY_LANGUAGES || entry->categoryId == SKILL_CATEGORY_GENERIC)
+                    continue;
+
+                if (player->HasSkill(entry->id))
+                    player->UpdateSkill(entry->id, step);
+#endif
             }
         }
 

--- a/methods/Mangos/PlayerMethods.h
+++ b/methods/Mangos/PlayerMethods.h
@@ -2978,11 +2978,11 @@ namespace LuaPlayer
         {
             if (SkillLineEntry const* entry = sSkillLineStore.LookupEntry(i))
             {
-                if (entry->categoryId == SKILL_CATEGORY_LANGUAGES || entry->categoryId == SKILL_CATEGORY_GENERIC)
+                if (entry->CategoryID == SKILL_CATEGORY_LANGUAGES || entry->CategoryID == SKILL_CATEGORY_GENERIC)
                     continue;
 
-                if (player->HasSkill(entry->id))
-                    player->UpdateSkill(entry->id, step);
+                if (player->HasSkill(entry->ID))
+                    player->UpdateSkill(entry->ID, step);
             }
         }
 

--- a/methods/Mangos/SpellMethods.h
+++ b/methods/Mangos/SpellMethods.h
@@ -54,7 +54,11 @@ namespace LuaSpell
      */
     int GetEntry(Eluna* E, Spell* spell)
     {
+#if ELUNA_EXPANSION == EXP_CLASSIC
         E->Push(spell->m_spellInfo->ID);
+#else
+        E->Push(spell->m_spellInfo->Id);
+#endif
         return 1;
     }
 

--- a/methods/Mangos/SpellMethods.h
+++ b/methods/Mangos/SpellMethods.h
@@ -54,7 +54,7 @@ namespace LuaSpell
      */
     int GetEntry(Eluna* E, Spell* spell)
     {
-        E->Push(spell->m_spellInfo->Id);
+        E->Push(spell->m_spellInfo->ID);
         return 1;
     }
 

--- a/methods/Mangos/UnitMethods.h
+++ b/methods/Mangos/UnitMethods.h
@@ -948,7 +948,7 @@ namespace LuaUnit
         if (!entry)
             return 1;
 
-        E->Push(entry->name[locale]);
+        E->Push(entry->Name_lang[locale]);
         return 1;
     }
 

--- a/methods/Mangos/UnitMethods.h
+++ b/methods/Mangos/UnitMethods.h
@@ -983,7 +983,7 @@ namespace LuaUnit
         if (!entry)
             return 1;
 
-        E->Push(entry->name[locale]);
+        E->Push(entry->Name_lang[locale]);
         return 1;
     }
 

--- a/methods/Mangos/UnitMethods.h
+++ b/methods/Mangos/UnitMethods.h
@@ -2417,6 +2417,10 @@ namespace LuaUnit
         SpellEntry const* spellEntry = sSpellStore.LookupEntry(spell);
 #ifdef CLASSIC
         unit->AddThreat(victim, threat, false, spellEntry ? GetSchoolMask(spellEntry->School) : SPELL_SCHOOL_MASK_NONE, spellEntry);
+#elif defined(MISTS)
+        // MoP (MISTS) split Spell.dbc: SpellEntry exposes a GetSchoolMask() accessor
+        // instead of a SchoolMask data member (which TBC/WotLK/Cata still have below).
+        unit->AddThreat(victim, threat, false, spellEntry ? static_cast<SpellSchoolMask>(spellEntry->GetSchoolMask()) : SPELL_SCHOOL_MASK_NONE, spellEntry);
 #else
         unit->AddThreat(victim, threat, false, spellEntry ? static_cast<SpellSchoolMask>(spellEntry->SchoolMask) : SPELL_SCHOOL_MASK_NONE, spellEntry);
 #endif

--- a/methods/Mangos/UnitMethods.h
+++ b/methods/Mangos/UnitMethods.h
@@ -948,7 +948,11 @@ namespace LuaUnit
         if (!entry)
             return 1;
 
+#if ELUNA_EXPANSION == EXP_CLASSIC
         E->Push(entry->Name_lang[locale]);
+#else
+        E->Push(entry->name[locale]);
+#endif
         return 1;
     }
 
@@ -983,7 +987,11 @@ namespace LuaUnit
         if (!entry)
             return 1;
 
+#if ELUNA_EXPANSION == EXP_CLASSIC
         E->Push(entry->Name_lang[locale]);
+#else
+        E->Push(entry->name[locale]);
+#endif
         return 1;
     }
 

--- a/methods/Mangos/WorldObjectMethods.h
+++ b/methods/Mangos/WorldObjectMethods.h
@@ -768,16 +768,28 @@ namespace LuaWorldObject
         int functionRef = luaL_ref(E->L, LUA_REGISTRYINDEX);
         if (functionRef != LUA_REFNIL && functionRef != LUA_NOREF)
         {
-            ElunaEventProcessor* proc = obj->GetElunaEvents(E->GetBoundMapId());
-            if (!proc)
+            // For MaNGOS, we need to get the event manager from Eluna
+            // Objects don't have direct event processor access
+            if (E && E->eventMgr)
+            {
+                uint64 procId = E->eventMgr->CreateObjectProcessor(obj);
+                ElunaEventProcessor* proc = E->eventMgr->GetObjectProcessor(procId);
+                if (proc)
+                {
+                    proc->AddEvent(functionRef, min, max, repeats);
+                    E->Push(functionRef);
+                }
+                else
+                {
+                    luaL_unref(E->L, LUA_REGISTRYINDEX, functionRef);
+                    E->Push();
+                }
+            }
+            else
             {
                 luaL_unref(E->L, LUA_REGISTRYINDEX, functionRef);
                 E->Push();
-                return 1;
             }
-
-            proc->AddEvent(functionRef, min, max, repeats);
-            E->Push(functionRef);
         }
         return 1;
     }
@@ -790,12 +802,11 @@ namespace LuaWorldObject
     int RemoveEventById(Eluna* E, WorldObject* obj)
     {
         int eventId = E->CHECKVAL<int>(2);
-        
-        ElunaEventProcessor* proc = obj->GetElunaEvents(E->GetBoundMapId());
-        if (!proc)
-            return 0;
 
-        proc->SetState(eventId, LUAEVENT_STATE_ABORT);
+        if (E && E->eventMgr)
+        {
+            E->eventMgr->SetEventState(eventId, LUAEVENT_STATE_ABORT);
+        }
         return 0;
     }
 
@@ -805,11 +816,10 @@ namespace LuaWorldObject
      */
     int RemoveEvents(Eluna* E, WorldObject* obj)
     {
-        ElunaEventProcessor* proc = obj->GetElunaEvents(E->GetBoundMapId());
-        if (!proc)
-            return 0;
-
-        proc->SetStates(LUAEVENT_STATE_ABORT);
+        if (E && E->eventMgr)
+        {
+            E->eventMgr->SetAllEventStates(LUAEVENT_STATE_ABORT);
+        }
         return 0;
     }
 

--- a/methods/Methods.cpp
+++ b/methods/Methods.cpp
@@ -23,12 +23,14 @@
 #include "GameObjectMethods.h"
 #include "ElunaQueryMethods.h"
 #include "AuraMethods.h"
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
 #include "AuraEffectMethods.h"
 #include "ElunaProcInfoMethods.h"
+#include "SpellInfoMethods.h"
+#endif
 #include "ItemMethods.h"
 #include "WorldPacketMethods.h"
 #include "SpellMethods.h"
-#include "SpellInfoMethods.h"
 #include "QuestMethods.h"
 #include "MapMethods.h"
 #include "CorpseMethods.h"
@@ -93,6 +95,7 @@ void RegisterMethods(Eluna* E)
     ElunaTemplate<Aura>::Register(E, "Aura");
     ElunaTemplate<Aura>::SetMethods(E, LuaAura::AuraMethods);
 
+#if defined ELUNA_TRINITY || defined ELUNA_AZEROTHCORE
     ElunaTemplate<AuraEffect>::Register(E, "AuraEffect");
     ElunaTemplate<AuraEffect>::SetMethods(E, LuaAuraEffects::AuraEffectMethods);
 
@@ -101,6 +104,7 @@ void RegisterMethods(Eluna* E)
 
     ElunaTemplate<ElunaSpellInfo>::Register(E, "ElunaSpellInfo");
     ElunaTemplate<ElunaSpellInfo>::SetMethods(E, LuaSpellInfo::SpellInfoMethods);
+#endif
 
     ElunaTemplate<Spell>::Register(E, "Spell");
     ElunaTemplate<Spell>::SetMethods(E, LuaSpell::SpellMethods);


### PR DESCRIPTION
## Expansion-guard DBC consumer accesses for mangos-zero's DBC alignment

mangos-zero is aligning its core `DBCStructure.h` field names to the client-verified 1.12 `.dbd` schema. Because this Eluna repo is **shared across the getMangos cores**, zero-only field renames can't be applied unconditionally to the shared `methods/`/`hooks/` code — the other cores keep the legacy names. This PR guards each affected access with `#if ELUNA_EXPANSION == EXP_CLASSIC` (new `.dbd` name) / `#else` (legacy name, restored verbatim), so the shared code compiles unchanged on every core.

### Guarded sites

| File | DBC field | CLASSIC | else (legacy) |
|------|-----------|---------|---------------|
| `hooks/CreatureHooks.cpp` ×2, `methods/Mangos/SpellMethods.h` | `SpellEntry` id | `->ID` | `->Id` |
| `hooks/ServerHooks.cpp` | `AreaTriggerEntry` id | `->ID` | `->id` |
| `methods/Mangos/GlobalMethods.h` | `AreaTableEntry` name | `->AreaName_lang` | `->area_name` |
| `methods/Mangos/GlobalMethods.h` | `TaxiPathNodeEntry` (8 fields) | `ContinentID`/`LocX`/… | `mapid`/`x`/… |
| `methods/Mangos/PlayerMethods.h` | `SkillLineEntry` | `->CategoryID`/`->ID` | `->categoryId`/`->id` |
| `methods/Mangos/UnitMethods.h` ×2 | `ChrClasses`/`ChrRaces` name | `->Name_lang` | `->name` |

All four cores (TBC/WotLK/Cata/MoP) were confirmed to share the identical legacy field names, so the `#else` branch is correct for every non-Classic core. **No behaviour change** — each core only compiles its own branch.

### Verification

Real `game`-target compiles (which is where these `methods/`/`hooks/` sources build) with this branch dropped into fresh core checkouts:

| Core | Result |
|------|--------|
| TBC | `game.lib` links, 0 errors |
| WotLK | `game.lib` links, 0 errors |
| Cata | `game.lib` links, 0 errors |

Cata additionally exercises the string fields against its `DBCString` (`char const* const*`) representation, confirming the `[locale]` indexing holds there too. (MoP uses the identical `DBCString` and legacy names.)
